### PR TITLE
dots3DMP 2D acc DDM flat bounds

### DIFF
--- a/dots3DMP/behav_models/dots3DMP_errfcn_DDM_2D_wConf_noMC.m
+++ b/dots3DMP/behav_models/dots3DMP_errfcn_DDM_2D_wConf_noMC.m
@@ -1,6 +1,6 @@
-function [err,fit,parsedFit,logOddsMap] = dots3DMP_errfcn_DDM_2D_wConf_noMC(param, guess, fixed, data, options)
+function [err,fit,parsedFit] = dots3DMP_errfcn_DDM_2D_wConf_noMC(param, guess, fixed, data, options)
 
-% updated model calculations to Steven's method: 
+% updated model calculations to Steven's method:
 % SJ 10-11-2021 no Monte Carlo simulation for fitting, it's redundant!
 % just use model predictions directly
 
@@ -9,11 +9,11 @@ function [err,fit,parsedFit,logOddsMap] = dots3DMP_errfcn_DDM_2D_wConf_noMC(para
 
 % SJ spawned 12-2022 from dots version, for dots3DMP
 
-tic
+errFuncStart = tic;
 
 global call_num
 
-% retrieve the full parameter set given the adjustable and fixed parameters 
+% retrieve the full parameter set given the adjustable and fixed parameters
 param = getParam(param, guess, fixed);
 if isfield(data,'dur')
     max_dur = max(data.dur)/1000; % max stimulus duration (s)
@@ -34,19 +34,14 @@ cohs = unique(data.coherence);
 mods = unique(data.modality);
 hdgs = unique(data.heading);
 
-if options.dummyRun == 0
-    deltas = 0;                  % fit only zero delta
-else
-    deltas = unique(data.delta); % predict all deltas
-end
-
 % separate kvis and kves
 kvis  = kmult*cohs'; % assume drift proportional to coh, reduces nParams
 kves  = mean(kvis); % for now, assume 'straddling'
 
-% ...but k for MOI for conf is constant
-if all(mods==1), k = kves;
-else, k = mean([kves kvis]);
+if options.dummyRun == 0
+    deltas = 0;                  % fit only zero delta
+else
+    deltas = unique(data.delta); % predict all deltas
 end
 
 
@@ -54,122 +49,41 @@ if options.useVelAcc
     % SJ 04/2020
     % Hou et al. 2019, peak vel = 0.37m/s, SD = 210ms
     % 07/2020 lab settings...16cm in 1.3s, sigma=0.14
-    
+
     % our theoretical settings (before tf)
     ampl = 0.16; % movement in metres
     pos = normcdf(1:max_dur*1000,max_dur*1000/2,0.14*1000)*ampl;
     vel = gradient(pos)*1000; % metres/s
-    acc = gradient(vel); 
+    acc = gradient(vel);
 
-    % normalize (by max or by mean?) and take abs of acc 
-%     vel = vel/mean(vel);
-%     acc = abs(acc)/mean(abs(acc));
+    % normalize (by max or by mean?) and take abs of acc
+    %     vel = vel/mean(vel);
+    %     acc = abs(acc)/mean(abs(acc));
     vel = vel/max(vel);
     acc = abs(acc)/max(abs(acc));
-    
 
-    if options.useVelAcc==1 
+
+    if options.useVelAcc==1
         sves = acc; svis = vel;
     elseif options.useVelAcc==2 % both vel
         sves = vel; svis = vel;
     elseif options.useVelAcc==3 % both acc
-        sves = acc; svis = acc; 
+        sves = acc; svis = acc;
     end
 else
     sves = ones(1,max_dur*1000);
     svis = sves;
 end
 
-% generate or load log odds correct map
 
-tConf = 0; % placeholder, should be a fit param eventually
+% SJ borrowed from Dots version 01-2023
+% for fitting RT dists, need to  clip any data.RTs that may be past the limit in the mapping
 
-% use method of images to calculate PDFs of DV and mapping to log odds corr
-R.t = 0.001:0.001:max_dur+tConf;
-R.Bup = B;
-R.drift = k * sind(hdgs(hdgs>=0)); % takes only unsigned drift rates
-
-R.lose_flag = 1; % we always need the losing densities
-R.plotflag = options.plot; % 1 = plot, 2 = plot nicer and export_fig (eg for talk)
-% R.plotflag = 1; % manual override
-Pconf = images_dtb_2d(R); % /WolpertMOI
-
-% dt = R.t(2)-R.t(1);
-% skipT = floor(tConf/dt);
-% Pconf.t(1:skipT) = [];
-% Pconf.logOddsCorrMap(:,1:skipT) = [];
-
-% use previously calculated logOddsMap if passed in
-if options.dummyRun==0
-    logOddsMap = Pconf.logOddsCorrMap;
-else
-    logOddsMap = options.logOddsMap;
-end
-
-% SJ copied from Dots version 01/16/2023
-% for fitting RT dists, need to  clip any data.RTs that may be past the
-% limit in the mapping
 dataRT_forPDF = data.RT;
-if sum(dataRT_forPDF>Pconf.t(end))/length(dataRT_forPDF)>0.05
+if sum(dataRT_forPDF>max_dur)/length(dataRT_forPDF) > 0.05
     warning('Lots of long RTs, check the data or extend the mapping')
 end
-dataRT_forPDF(dataRT_forPDF>Pconf.t(end)) = Pconf.t(end);
-
-%% now compute a separate P for model choices and RTs (where drift rate is modality-specific)
-
-% ves
-RVes.t = 0.001:0.001:max_dur;
-RVes.Bup = B;
-RVes.drift = sves .* kves .* sind(hdgs(hdgs>=0));
-RVes.driftSigned = kves * sind(hdgs); % sves is not needed here
-
-RVes.lose_flag = 1;
-RVes.plotflag = 0;
-PVes =  images_dtb_2d_varDrift(RVes);
-
-% vis and comb, separate drift for each coh
-for c = 1:length(cohs)
-    RVis.t = 0.001:0.001:max_dur;
-    RVis.Bup = B;
-    RVis.drift = svis .* kvis(c) .* sind(hdgs(hdgs>=0));
-    RVis.driftSigned = kvis(c) * sind(hdgs);
-
-    RVis.lose_flag = 1;
-    RVis.plotflag = 0;
-    PVis(c) =  images_dtb_2d_varDrift(RVis);
-
-    RComb.t = 0.001:0.001:max_dur;
-    RComb.Bup = B;
-    RComb.lose_flag = 1;
-    RComb.plotflag = 0;
-
-    if options.dummyRun == 0
-      
-        kcomb(c) = sqrt(kves.^2 + kvis(c).^2); % optimal per Drugo
-        RComb.driftSigned = kcomb(c) * sind(hdgs);
-
-        kcombT(c,:) = sqrt(sves.*kves.^2 + svis.*kvis(c).^2); % optimal per Drugo
-        RComb.drift = kcombT(c,:) .* sind(hdgs(hdgs>=0));
-        PComb(c,1) =  images_dtb_2d_varDrift(RComb);
-
-    else     % compute w and mu to capture biases under cue conflict
-        
-        wVes = sqrt( kves^2 / (kves^2 + kvis(c)^2) );
-        wVis = sqrt( kvis(c)^2 / (kves^2 + kvis(c)^2) );
-        
-        for d = 1:length(deltas)
-            % positive delta defined as ves to the left, vis to the right
-            muVes = kves    * sind(hdgs-deltas(d)/2);
-            muVis = kvis(c) * sind(hdgs+deltas(d)/2);
-
-            RComb.driftSigned = wVes.*muVes + wVis.*muVis;
-            RComb.drift = abs(sves.*wVes.*muVes + svis.*wVis.*muVis);
-
-%             RComb.drift = abs(RComb.driftSigned);
-            PComb(c,d) =  images_dtb_2d_varDrift(RComb);
-        end
-    end
-end
+dataRT_forPDF(dataRT_forPDF>max_dur) = max_dur;
 
 
 %% calculate likelihood of the observed data given the model parameters
@@ -181,10 +95,10 @@ usetrs_data = true(size(data.correct)); % try all trials
 n = nan(length(mods),length(cohs),length(deltas),length(hdgs));
 pRight_model        = n;
 pHigh_model         = n;
-pRightHigh_model    = n;
-pRightLow_model     = n;
-pLeftHigh_model     = n;
-pLeftLow_model      = n;
+% pRightHigh_model    = n;
+% pRightLow_model     = n;
+% pLeftHigh_model     = n;
+% pLeftLow_model      = n;
 pHighCorr_model     = n;
 pHighErr_model      = n;
 meanConf_model      = n;
@@ -192,8 +106,8 @@ meanRT_model        = n;
 meanRThigh_model    = n;
 meanRTlow_model     = n;
 
-pRight_High_model    = n;
-pRight_Low_model     = n;
+pRight_High_model   = n;
+pRight_Low_model    = n;
 
 meanRT_data         = n;
 meanRThigh_data     = n;
@@ -203,7 +117,7 @@ meanRTlow_data      = n;
 % sigmaRTlow_data     = n;
 meanConf_data       = n;
 sigmaConf_data      = n;
-nCor                = n;
+% nCor                = n;
 
 nTrials             = n;
 
@@ -234,312 +148,391 @@ sigmaRT_model_trialwise     = m;
 sigmaRThigh_model_trialwise = m;
 sigmaRTlow_model_trialwise  = m;
 L_RT_fromPDF      = m;
-L_RT_high_fromPDF = m;
-L_RT_low_fromPDF  = m;
+% L_RT_PDW_fromPDF = m;
+L_RT_PDW_fromPDF  = m;
+
+
+% going to calculate separate confidence mapping for each modality since we
+% are using temporal weighting
+
+% SJ 01-2023 
+
+R.t = 0.001:0.001:max_dur;
+R.Bup = B;
+R.lose_flag = any(contains(options.whichFit,{'conf','multinom'})); % only get losing distributions if we are fitting confidence
+R.plotflag  = 0;
 
 for m = 1:length(mods)
 
-    if mods(m)==1, P = PVes; end
     Tnd = Tnds(m);
     TndSD = 0;
 
-for c = 1:length(cohs) 
+    for c = 1:length(cohs)
+
+        for d = 1:length(deltas)
+
+            if deltas(d)~=0 && mods(m)~=3, continue, end
+
+            if mods(m)==1
+                R.drift = sves .* kves .* sind(hdgs(hdgs>=0));
+                R.driftSigned = kves * sind(hdgs); % sves is not needed here, since we only care about the overall sign for right vs left.
+            
+            elseif mods(m)==2
+                R.drift = svis .* kvis(c) .* sind(hdgs(hdgs>=0));
+                R.driftSigned = kvis(c) * sind(hdgs);
+            
+            elseif mods(m)==3
+
+                if options.dummyRun == 0
+                    % 'kcomb'
+                    R.driftSigned = sqrt(kves.^2 + kvis(c).^2) * sind(hdgs);
+                    R.drift     = sqrt(sves.*kves.^2 + svis.*kvis(c).^2) .* sind(hdgs(hdgs>=0));
+
+                else     % compute w and mu, and use signed headings, to capture biases under cue conflict
+
+                    wVes = sqrt( kves^2 / (kves^2 + kvis(c)^2) );
+                    wVis = sqrt( kvis(c)^2 / (kves^2 + kvis(c)^2) );
+
+                    % positive delta defined as ves to the left, vis to the right
+                    muVes = kves    * sind(hdgs-deltas(d)/2);
+                    muVis = kvis(c) * sind(hdgs+deltas(d)/2);
+
+                    R.driftSigned = wVes.*muVes + wVis.*muVis;
+                    R.drift       = abs(sves.*wVes.*muVes + svis.*wVis.*muVis);
+
+                end
+
+            end
+            
+            P = images_dtb_2d_varDrift(R);
+
+%             if options.dummyRun==0
+                logOddsMap = P.logOddsCorrMap;
+%             else
+%                 logOddsMap = P.logOddsCorrMap; % need to pass in maps?
+%             end
+
+            for h = 1:length(hdgs)
 
 
-for d = 1:length(deltas)
-    
-    if deltas(d)~=0 && mods(m)~=3, continue, end
+                Jdata  = data.modality==mods(m) & data.coherence==cohs(c) & data.heading==hdgs(h) & data.delta==deltas(d);
+                nTrials(m,c,d,h) = sum(Jdata);
 
-    if mods(m)==2, P = PVis(c);
-    elseif mods(m)==3, P = PComb(c,d);
-    end
+                % empirical probabilities from data (actually just take counts
+                % 'successes', for pdf functions
+                %     nRight_data(m,c,d,h) = sum(Jdata & data.choice==1); % choice is logical 0..1!!
+                %
+                %     if options.conftask==2
+                %         nHigh_data(m,c,d,h)  = sum(Jdata & data.PDW==1);
+                %
+                %         nRightHigh_data(m,c,d,h) = sum(Jdata & data.choice==1 & data.PDW==1);
+                %         nRightLow_data(m,c,d,h)  = sum(Jdata & data.choice==1 & data.PDW==0);
+                %         nLeftHigh_data(m,c,d,h)  = sum(Jdata & data.choice==0 & data.PDW==1);
+                %         nLeftLow_data(m,c,d,h)   = sum(Jdata & data.choice==0 & data.PDW==0);
+                %     end
+
+                % index for images_dtb (unsigned hdg/drift corresponding to this signed hdg)
+                if options.dummyRun==1 && mods(m)==3
+                    uh = h; % for cue conflict, drift rates are not symmetrical around 0
+                else
+                    uh = abs(hdgs(h))==(hdgs(hdgs>=0));
+                end
+
+                if R.lose_flag
+                    % grab the distributions from images_dtb:
+                    Pxt1 = squeeze(P.up.distr_loser(uh,:,:))'; % losing race pdf given correct
+                    Pxt2 = squeeze(P.lo.distr_loser(uh,:,:))'; % losing race pdf given incorrect
+                end
+
+                % CHOICE & PDW
+                % yes, we can fit non-zero bias, just need to use the bias-corrected signed
+                % drift rate, rather than the experimenter-defined headings!
+
+                if P.driftSigned(h)<0 % leftward motion
+                    % if hdg is negative, then pRight is p(incorrect), aka P.lo
+                    pRight = P.lo.p(uh)/(P.up.p(uh)+P.lo.p(uh)); % normalized by total bound-crossing probability
+                    pLeft = 1-pRight; % (evidently, the unabsorbed probability can be ignored when it comes to pRight)
 
 
-for h = 1:length(hdgs)
+                    if R.lose_flag
+                        % calculate probabilities of the four outcomes: right/left x high/low
+                        % these are the intersections, e.g. P(R n H)
+                        pRightHigh = sum(sum(Pxt2.*(P.logOddsCorrMap>=theta(m))));
+                        pRightLow = sum(sum(Pxt2.*(P.logOddsCorrMap<theta(m))));
+                        pLeftHigh = sum(sum(Pxt1.*(P.logOddsCorrMap>=theta(m))));
+                        pLeftLow =  sum(sum(Pxt1.*(P.logOddsCorrMap<theta(m))));
+                    end
 
-    
-    Jdata  = data.modality==mods(m) & data.coherence==cohs(c) & data.heading==hdgs(h) & data.delta==deltas(d);
-    nTrials(m,c,d,h) = sum(Jdata);
+                else % rightward motion (and zero motion is symmetrical so gets taken care of here too)
 
-    % empirical probabilities from data (actually just take counts
-    % 'successes', for pdf functions
-    nRight_data(m,c,d,h) = sum(Jdata & data.choice==1); % choice is logical 0..1!!
-    
-    if options.conftask==2
-        nHigh_data(m,c,d,h)  = sum(Jdata & data.PDW==1); 
+                    % if hdg is positive, then pRight is p(correct), aka P.up
+                    try
+                    pRight = P.up.p(uh)/(P.up.p(uh)+P.lo.p(uh)); % normalized by total bound-crossing probability
+                    pLeft = 1-pRight;
+                    catch
+                        keyboard
+                    end
 
-        nRightHigh_data(m,c,d,h) = sum(Jdata & data.choice==1 & data.PDW==1);
-        nRightLow_data(m,c,d,h)  = sum(Jdata & data.choice==1 & data.PDW==0);
-        nLeftHigh_data(m,c,d,h)  = sum(Jdata & data.choice==0 & data.PDW==1);
-        nLeftLow_data(m,c,d,h)   = sum(Jdata & data.choice==0 & data.PDW==0);
-    end
+                    if R.lose_flag
+                        % calculate probabilities of the four outcomes: right/left x high/low
+                        % these are the intersections, e.g. P(R n H)
+                        pRightHigh = sum(sum(Pxt1.*(logOddsMap>=theta(m))));
+                        pRightLow = sum(sum(Pxt1.*(logOddsMap<theta(m))));
+                        pLeftHigh = sum(sum(Pxt2.*(logOddsMap>=theta(m))));
+                        pLeftLow =  sum(sum(Pxt2.*(logOddsMap<theta(m))));
+                    end
+                end
 
-    % index for images_dtb (unsigned hdg/drift corresponding to this signed hdg)
-    if options.dummyRun==1 && mods(m)==3
-        uh = h; % for cue conflict, drift rates are not symmetrical around 0
-    else
-        uh = abs(hdgs(h))==(hdgs(hdgs>=0));  
-    end
 
-    % grab the distributions from images_dtb:
-    Pxt1 = squeeze(P.up.distr_loser(uh,:,:))'; % losing race pdf given correct
-    Pxt2 = squeeze(P.lo.distr_loser(uh,:,:))'; % losing race pdf given incorrect
-   
-    % CHOICE & PDW
-    % yes, we can fit non-zero bias, just need to use the bias-corrected signed
-    % drift rate, rather than the experimenter-defined headings!
+                if R.lose_flag
 
-    if P.driftSigned(h)<0 % leftward motion
-        % if hdg is negative, then pRight is p(incorrect), aka P.lo
-        pRight = P.lo.p(uh)/(P.up.p(uh)+P.lo.p(uh)); % normalized by total bound-crossing probability 
-        pLeft = 1-pRight; % (evidently, the unabsorbed probability can be ignored when it comes to pRight)
+                %ensure total prob sums to one (when it doesn't, it's because of unabsorbed prob)
+                % THIS STEP WASN'T THOUGHT TO BE NECESSARY FOR PARAM RECOV, SO BE
+                % CAREFUL AND REMOVE IT IF IT MUCKS IT UP
+                Ptot = pRightHigh + pRightLow + pLeftHigh + pLeftLow;
+                %if abs(Ptot-1)>1e-6; warning('Ptot'); keyboard, fprintf('m=%d, c=%g, h=%g\tPtot=%.2f\n',mods(m),cohs(c),hdgs(h),Ptot); end
+                pRightHigh = pRightHigh/Ptot;
+                pRightLow  = pRightLow/Ptot;
+                pLeftHigh  = pLeftHigh/Ptot;
+                pLeftLow   = pLeftLow/Ptot;
 
-        % calculate probabilities of the four outcomes: right/left x high/low
-        % these are the intersections, e.g. P(R n H)
-        pRightHigh = sum(sum(Pxt2.*(logOddsMap>=theta(m))));
-        pRightLow = sum(sum(Pxt2.*(logOddsMap<theta(m))));
-        pLeftHigh = sum(sum(Pxt1.*(logOddsMap>=theta(m))));
-        pLeftLow =  sum(sum(Pxt1.*(logOddsMap<theta(m))));                                                             
-    
-    else % rightward motion (and zero motion is symmetrical so gets taken care of here too)
+                %     % these are intersections, for model fitting
+                %     pRightHigh_model(m,c,d,h) = pRightHigh;
+                %     pRightLow_model(m,c,d,h) = pRightLow;
+                %     pLeftHigh_model(m,c,d,h) = pLeftHigh;
+                %     pLeftLow_model(m,c,d,h) = pLeftLow;
+                %
+                %     % copy intersections to trials, for multinomial likelihood
+                %     pRightHigh_model_trialwise(Jdata) = pRightHigh;
+                %     pRightLow_model_trialwise(Jdata) = pRightLow;
+                %     pLeftHigh_model_trialwise(Jdata) = pLeftHigh;
+                %     pLeftLow_model_trialwise(Jdata) = pLeftLow;
+                % this step now occurs below, after incorporating alpha
 
-        % if hdg is positive, then pRight is p(correct), aka P.up
-        pRight = P.up.p(uh)/(P.up.p(uh)+P.lo.p(uh)); % normalized by total bound-crossing probability
-        pLeft = 1-pRight;
+                % by definition of conditional probability: P(A|B) = P(A n B) / P(B)
+                pHigh_Right = pRightHigh / pRight;
+                pLow_Right = pRightLow / pRight;
+                pHigh_Left = pLeftHigh / pLeft;
+                pLow_Left = pLeftLow / pLeft;
 
-        % calculate probabilities of the four outcomes: right/left x high/low
-        % these are the intersections, e.g. P(R n H)
-        pRightHigh = sum(sum(Pxt1.*(logOddsMap>=theta(m))));
-        pRightLow = sum(sum(Pxt1.*(logOddsMap<theta(m))));
-        pLeftHigh = sum(sum(Pxt2.*(logOddsMap>=theta(m))));
-        pLeftLow =  sum(sum(Pxt2.*(logOddsMap<theta(m))));                                                     
-    end
+                % by law of total probability
+                pHigh = pHigh_Right*pRight + pHigh_Left*pLeft;
+                pLow = pLow_Right*pRight + pLow_Left*pLeft; % why isn't this 1-pHigh? probability is so weird.
 
-    %ensure total prob sums to one (when it doesn't, it's because of unabsorbed prob)
-    % THIS STEP WASN'T THOUGHT TO BE NECESSARY FOR PARAM RECOV, SO BE
-    % CAREFUL AND REMOVE IT IF IT MUCKS IT UP
-    Ptot = pRightHigh + pRightLow + pLeftHigh + pLeftLow;
-    if abs(Ptot-1)>1e-6; warning('Ptot'); fprintf('m=%d,c=%d,h=%d, Ptot=%f\n',mods(m),cohs(c),hdgs(h),Ptot); end
-    pRightHigh = pRightHigh/Ptot;
-    pRightLow  = pRightLow/Ptot;
-    pLeftHigh  = pLeftHigh/Ptot;
-    pLeftLow   = pLeftLow/Ptot;
+                % by Bayes' rule: choive GIVEN wager
+                pRight_High = pHigh_Right * pRight / pHigh;
+                pRight_Low = pLow_Right * pRight / pLow;
+                pLeft_High = pHigh_Left * pLeft / pHigh;
+                pLeft_Low = pLow_Left * pLeft / pLow;
 
-%     % these are intersections, for model fitting
-%     pRightHigh_model(m,c,d,h) = pRightHigh;
-%     pRightLow_model(m,c,d,h) = pRightLow;
-%     pLeftHigh_model(m,c,d,h) = pLeftHigh;
-%     pLeftLow_model(m,c,d,h) = pLeftLow;
-% 
-%     % copy intersections to trials, for multinomial likelihood
-%     pRightHigh_model_trialwise(Jdata) = pRightHigh;
-%     pRightLow_model_trialwise(Jdata) = pRightLow;
-%     pLeftHigh_model_trialwise(Jdata) = pLeftHigh;
-%     pLeftLow_model_trialwise(Jdata) = pLeftLow;
-    % this step now occurs below, after incorporating alpha 
+                % adjust the probabilities for the base rate of low-conf bets (alpha)
+                pHigh_wAlpha = pHigh - alpha*pHigh;
 
-    
-    % by definition of conditional probability: P(A|B) = P(A n B) / P(B)
-    pHigh_Right = pRightHigh / pRight;
-    pLow_Right = pRightLow / pRight; 
-    pHigh_Left = pLeftHigh / pLeft;
-    pLow_Left = pLeftLow / pLeft;  
-    
-    % by law of total probability
-    pHigh = pHigh_Right*pRight + pHigh_Left*pLeft;
-    pLow = pLow_Right*pRight + pLow_Left*pLeft; % why isn't this 1-pHigh? probability is so weird.
+                % Lastly, the PDW split; use Bayes to adjust P(H|R) and P(H|L)
+                pHigh_Right_wAlpha = pRight_High * pHigh_wAlpha / pRight;
+                pHigh_Left_wAlpha = pLeft_High * pHigh_wAlpha / pLeft;
+                if hdgs(h)<0 % leftward motion
+                    pHigh_Corr = pHigh_Left_wAlpha;
+                    pHigh_Err = pHigh_Right_wAlpha;
+                else % rightward motion
+                    pHigh_Corr = pHigh_Right_wAlpha;
+                    pHigh_Err = pHigh_Left_wAlpha;
+                end
 
-    % by Bayes' rule:
-    pRight_High = pHigh_Right * pRight / pHigh;
-    pRight_Low = pLow_Right * pRight / pLow;
-    pLeft_High = pHigh_Left * pLeft / pHigh;
-    pLeft_Low = pLow_Left * pLeft / pLow; %#ok<NASGU>
+                % and use (rearranged) definition of conditional probability to adjust
+                % the intersections
+                pRightHigh_wAlpha = pHigh_wAlpha * pRight_High;
+                pRightLow_wAlpha = (1-pHigh_wAlpha) * pRight_Low;
+                pLeftHigh_wAlpha = pHigh_wAlpha * pLeft_High;
+                pLeftLow_wAlpha = (1-pHigh_wAlpha) * pLeft_Low;
 
-    % adjust the probabilities for the base rate of low-conf bets (alpha)
-    pHigh_wAlpha = pHigh - alpha*pHigh;
+                % still should sum to 1
+                Ptot = pRightHigh_wAlpha + pRightLow_wAlpha + pLeftHigh_wAlpha + pLeftLow_wAlpha;
+                if abs(Ptot-1)>1e-6; warning('Ptot'); fprintf('m=%d, c=%g, h=%g\tPtot=%.2f\n',mods(m),cohs(c),hdgs(h),Ptot); end
+                pRightHigh_wAlpha = pRightHigh_wAlpha/Ptot;
+                pRightLow_wAlpha = pRightLow_wAlpha/Ptot;
+                pLeftHigh_wAlpha = pLeftHigh_wAlpha/Ptot;
+                pLeftLow_wAlpha = pLeftLow_wAlpha/Ptot;
 
-    % Lastly, the PDW split; use Bayes to adjust P(H|R) and P(H|L)
-    pHigh_Right_wAlpha = pRight_High * pHigh_wAlpha / pRight;
-    pHigh_Left_wAlpha = pLeft_High * pHigh_wAlpha / pLeft;
-    if hdgs(h)<0 % leftward motion
-        pHigh_Corr = pHigh_Left_wAlpha;
-        pHigh_Err = pHigh_Right_wAlpha;
-    else % rightward motion
-        pHigh_Corr = pHigh_Right_wAlpha;
-        pHigh_Err = pHigh_Left_wAlpha;    
-    end
-    
-    % and use (rearranged) definition of conditional probability to adjust
-    % the intersections
-    pRightHigh_wAlpha = pHigh_wAlpha * pRight_High;
-    pRightLow_wAlpha = (1-pHigh_wAlpha) * pRight_Low;
-    pLeftHigh_wAlpha = pHigh_wAlpha * pLeft_High;
-    pLeftLow_wAlpha = (1-pHigh_wAlpha) * pLeft_Low;
+                % copy intersections to trials, for multinomial likelihood
+                % *NOW INCLUDES effect of alpha
+                pRightHigh_model_trialwise(Jdata) = pRightHigh_wAlpha;
+                pRightLow_model_trialwise(Jdata) = pRightLow_wAlpha;
+                pLeftHigh_model_trialwise(Jdata) = pLeftHigh_wAlpha;
+                pLeftLow_model_trialwise(Jdata) = pLeftLow_wAlpha;
 
-    % still should sum to 1
-    Ptot = pRightHigh_wAlpha + pRightLow_wAlpha + pLeftHigh_wAlpha + pLeftLow_wAlpha;
-    if abs(Ptot-1)>1e-6; warning('Ptot'); fprintf('m=%d,c=%d,h=%d, Ptot=%f\n',mods(m),cohs(c),hdgs(h),Ptot); end
-    pRightHigh_wAlpha = pRightHigh_wAlpha/Ptot;
-    pRightLow_wAlpha = pRightLow_wAlpha/Ptot;
-    pLeftHigh_wAlpha = pLeftHigh_wAlpha/Ptot;
-    pLeftLow_wAlpha = pLeftLow_wAlpha/Ptot;
+                % copy to vectors for parsedFit struct
+                pHigh_model(m,c,d,h) = pHigh_wAlpha; % includes the effect of alpha
+                pRight_High_model(m,c,d,h) = pRight_High; % does NOT include the effect of alpha, since bet high/low is already a given
+                pRight_Low_model(m,c,d,h) = pRight_Low; % does NOT include the effect of alpha
 
-    % copy intersections to trials, for multinomial likelihood
-    % *NOW INCLUDES effect of alpha
-    pRightHigh_model_trialwise(Jdata) = pRightHigh_wAlpha;
-    pRightLow_model_trialwise(Jdata) = pRightLow_wAlpha;
-    pLeftHigh_model_trialwise(Jdata) = pLeftHigh_wAlpha;
-    pLeftLow_model_trialwise(Jdata) = pLeftLow_wAlpha;
-        
-    % copy to vectors for parsedFit struct
-    pRight_model(m,c,d,h) = pRight;
-    pHigh_model(m,c,d,h) = pHigh_wAlpha; % includes the effect of alpha
-    pRight_High_model(m,c,d,h) = pRight_High; % does NOT include the effect of alpha, since bet high/low is already a given
-    pRight_Low_model(m,c,d,h) = pRight_Low; % does NOT include the effect of alpha
-    
-    pHigh_Corr_model(m,c,d,h) = pHigh_Corr; % includes the effect of alpha
-    pHigh_Err_model(m,c,d,h) = pHigh_Err; % includes the effect of alpha
+                pHigh_Corr_model(m,c,d,h) = pHigh_Corr; % includes the effect of alpha
+                pHigh_Err_model(m,c,d,h) = pHigh_Err; % includes the effect of alpha
 
-    % copy to trials for fit struct
-    pRight_model_trialwise(Jdata) = pRight_model(m,c,d,h);
-    pHigh_model_trialwise(Jdata) = pHigh_model(m,c,d,h);
-    pRight_High_model_trialwise(Jdata) = pRight_High_model(m,c,d,h);
-    pRight_Low_model_trialwise(Jdata) = pRight_Low_model(m,c,d,h);
-    pHigh_Corr_model_trialwise(Jdata) = pHighCorr_model(m,c,d,h);
-    pHigh_Err_model_trialwise(Jdata) = pHighErr_model(m,c,d,h);
-        
-    % ************
-    % RT
-    % ************
-%     nCor(c) = sum(Jdata & (data.correct | abs(data.heading)<1e-6));
-    if options.RTtask
-        
-        % different Tnds for different choices, NOT for different cohs,
-        % so we simply take a weighted average based on P(right)
-%         Tnd = TndR*pRight + TndL*(1-pRight);
-        
-        % for param-recov, model RT needs adjusted to account for unabsorbed
-        % probability (trials that don't hit the bound, usually only at low
-        % cohs, when bound is high, etc). Turns out the calculation of
-        % P.up.mean_t only applies to absorbed prob (bound-crossings), so
-        % we simply adjust it by averaging mean_t with maxdur, weighted by
-        % one minus the probability of bound crossing
-            % (this was a cool exercise when it worked, but seems easier to
-            % exclude those trials and pretend there is no unabsorbed prob;
-            % also more consistent with real behavior where there's always a
-            % choice before max_dur is reached  --thanks to MVL for this)
-        if options.ignoreUnabs
-            pHB = 1;
-        else
-            pHB = P.up.p(uh)+P.lo.p(uh); % prob of crossing either bound
+                % copy to trials for fit struct
+                pHigh_model_trialwise(Jdata) = pHigh_model(m,c,d,h);
+                pRight_High_model_trialwise(Jdata) = pRight_High_model(m,c,d,h);
+                pRight_Low_model_trialwise(Jdata) = pRight_Low_model(m,c,d,h);
+                pHigh_Corr_model_trialwise(Jdata) = pHighCorr_model(m,c,d,h);
+                pHigh_Err_model_trialwise(Jdata) = pHighErr_model(m,c,d,h);
+
+                end
+
+                pRight_model(m,c,d,h) = pRight;
+                pRight_model_trialwise(Jdata) = pRight_model(m,c,d,h);
+
+                % ************
+                % RT
+                % ************
+                %     nCor(c) = sum(Jdata & (data.correct | abs(data.heading)<1e-6));
+                if options.RTtask
+
+                    % different Tnds for different choices, NOT for different cohs,
+                    % so we simply take a weighted average based on P(right)
+                    %         Tnd = TndR*pRight + TndL*(1-pRight);
+
+                    % for param-recov, model RT needs adjusted to account for unabsorbed
+                    % probability (trials that don't hit the bound, usually only at low
+                    % cohs, when bound is high, etc). Turns out the calculation of
+                    % P.up.mean_t only applies to absorbed prob (bound-crossings), so
+                    % we simply adjust it by averaging mean_t with maxdur, weighted by
+                    % one minus the probability of bound crossing
+                    % (this was a cool exercise when it worked, but seems easier to
+                    % exclude those trials and pretend there is no unabsorbed prob;
+                    % also more consistent with real behavior where there's always a
+                    % choice before max_dur is reached  --thanks to MVL for this)
+                    if options.ignoreUnabs
+                        pHB = 1;
+                    else
+                        pHB = P.up.p(uh)+P.lo.p(uh); % prob of crossing either bound
+                    end
+
+
+                    %         meanRT_model(m,c,d,h) = P.up.p(uh)*P.up.mean_t(uh) + P.lo.p(uh)*P.lo.mean_t(uh) + (1-pHB)*max_dur + Tnd; % weighted average
+                    meanRT_model(m,c,d,h) = pHB*P.up.mean_t(uh) + (1-pHB)*max_dur + Tnd; % weighted average
+                    %         varRT_model(m,c,d,h)  = pHB*P.up.var_t(uh)  + (1-pHB)*0 + TndSD.^2; % TndSD?
+
+
+                    if R.lose_flag
+                    % for RT conditioned on wager, it seems we don't need to do any
+                    % scaling by Ptb; the correct distribution is captured by the
+                    % conditional Pxts, we just sum them, dot product w t and normalize
+                    PxtAboveTheta = sum(Pxt1.*(logOddsMap>=theta(m))); % shouldn't matter if Pxt1 or 2, it's symmetric
+                    PxtBelowTheta = sum(Pxt1.*(logOddsMap<theta(m)));
+
+                    PxtAboveTheta2 = sum(Pxt2.*(logOddsMap>=theta(m))); % shouldn't matter if Pxt1 or 2, it's symmetric
+                    PxtBelowTheta2 = sum(Pxt2.*(logOddsMap<theta(m)));
+
+                    meanRThigh = PxtAboveTheta * R.t' / sum(PxtAboveTheta);
+                    meanRTlow  = PxtBelowTheta * R.t' / sum(PxtBelowTheta);
+
+                    meanRThigh = ( (PxtAboveTheta * P.up.p(uh) / sum(PxtAboveTheta)) + (PxtAboveTheta2 * P.lo.p(uh) / sum(PxtAboveTheta2))) * R.t';
+                    meanRTlow = ( (PxtBelowTheta * P.up.p(uh) / sum(PxtBelowTheta)) + (PxtBelowTheta2 * P.lo.p(uh) / sum(PxtBelowTheta2))) * R.t';
+
+                    % BUT these also need to factor in unabsorbed probability
+                    % (ie weighted average with max_dur). Intuitively, we know that we
+                    % must scale pHB up for high bets, down for low bets. But I was
+                    % unable to calculate the adjusted pHBs and gave up, for now (see
+                    % old notes)
+                    % Instead, just set both to pHB, which is close enough when pHB>.98
+                    pHBhigh = pHB;
+                    pHBlow = pHB;
+
+                    meanRThigh_model(m,c,d,h) = pHBhigh*meanRThigh + (1-pHBhigh)*max_dur + Tnd;
+                    meanRTlow_model(m,c,d,h) = pHBlow*meanRTlow + (1-pHBlow)*max_dur + Tnd;
+
+                    % copy to trials
+                    RThigh_model_trialwise(Jdata) = meanRThigh_model(m,c,d,h);
+                    RTlow_model_trialwise(Jdata) = meanRTlow_model(m,c,d,h);
+
+                    end
+
+                    RT_model_trialwise(Jdata) = meanRT_model(m,c,d,h);
+
+                    % TEMP(?): compute the variances of these PDFs for the
+                    % fitting-by-mean RT likelihood calculations below. This may become
+                    % obsolete if we can use the PDFs themselves
+
+                    % variance = sum((x - mean).^2 .* y)
+                    % where x is the domain of the PDF, y is the PDF values over the
+                    % domain x, and mean is the mean of the PDF, which you can
+                    % calculate using the formula you provided: mean = sum(y.*x). -- thanks ChatGPT!
+
+                    % % %         % SJ 12-2022 Is diag is what we want here? Var(X) = E((X-E(X))^2)
+                    % % %         P.up.var_t = diag(P.up.pdf_t * ((R.t - P.up.mean_t).^2)' ./ P.up.p);
+                    % % %         P.lo.var_t = diag(P.lo.pdf_t * ((R.t - P.lo.mean_t).^2)' ./ P.lo.p);
+
+                    % ___note the PDFs are normalized___
+                    sigmaRT_model(m,c,d,h) = sqrt(sum((R.t - P.up.mean_t(uh)).^2 .* P.up.pdf_t(uh,:)/sum(P.up.pdf_t(uh,:))));
+                    
+                    if R.lose_flag
+                        sigmaRThigh_model(m,c,d,h) = sqrt(sum((R.t - meanRThigh).^2 .* PxtAboveTheta/sum(PxtAboveTheta)));
+                        sigmaRTlow_model(m,c,d,h) = sqrt(sum((R.t - meanRTlow).^2 .* PxtBelowTheta/sum(PxtBelowTheta)));
+                   
+                    end
+
+                    % (note these do not include any variance added from convolution w Tnd dist)
+                    sigmaRT_model_trialwise(Jdata) = sigmaRT_model(m,c,d,h);
+
+                    if R.lose_flag
+                        sigmaRThigh_model_trialwise(Jdata) = sigmaRThigh_model(m,c,d,h);
+                        sigmaRTlow_model_trialwise(Jdata) = sigmaRTlow_model(m,c,d,h);
+                    end
+
+                    % grab the mean and sd(se?) for corresponding data
+                    I = Jdata & usetrs_data;
+                    n_RT_data(m,c,d,h) = sum(I);
+                    meanRT_data(m,c,d,h) = mean(data.RT(I));
+                    sigmaRT_data(m,c,d,h) = std(data.RT(I))/sqrt(sum(I)); % SD or SEM? --*obsolete even if not using full dists, use Sigma from the dist itself
+                    sigmaRT_data_trialwise(Jdata) = sigmaRT_data(c); % copy to trials, for alternate LL calculation below
+                    % (should this be Jdata or I?)
+
+                    % but we can just get the likelihood directly from the PDF!
+                    PDF = P.up.pdf_t(uh,:)/sum(P.up.pdf_t(uh,:)); % renormalize
+                    PDF2 = P.lo.pdf_t(uh,:)/sum(P.lo.pdf_t(uh,:)); % renormalize
+
+                    TndDist = normpdf(P.t,Tnd,2e-4)/sum(normpdf(P.t,Tnd,2e-4));
+
+                    PDFwTnd = conv(PDF,TndDist); % convolve with ^Tnd dist (currently zero variance, approx something tiny)
+                    PDFwTnd = PDFwTnd(1:length(P.t))/sum(PDFwTnd(1:length(P.t))); % normalize again and trim the extra length from conv
+                    % figure;plot(PDF,'b');hold on; plot(PDFwTnd,'r'); % temp, just to see that the conv makes sense
+                    L_RT_fromPDF(I) = PDFwTnd(round(dataRT_forPDF(I)*1000))';
+
+                    if R.lose_flag
+                        % repeat for high/low
+                        %         I = Jdata & usetrs_data & data.PDW_preAlpha==1;
+                        I = Jdata & usetrs_data & data.PDW==1;
+                        n_RThigh_data(m,c,d,h) = sum(I);
+                        meanRThigh_data(m,c,d,h) = mean(data.RT(I));
+                        %         sigmaRThigh_data(m,c,d,h) = std(data.RT(I))/sqrt(sum(I)); % SD or SEM?
+                        %         sigmaRThigh_data_trialwise(Jdata) = sigmaRThigh_data(h); % copy to trials, for alternate LL calculation below
+
+                        % but we can just get the likelihood directly from the PDF!
+                        PDF = PxtAboveTheta/sum(PxtAboveTheta);
+                        PDFwTnd = conv(PDF,TndDist);
+                        PDFwTnd = PDFwTnd(1:length(P.t))/sum(PDFwTnd(1:length(P.t)));
+                        L_RT_PDW_fromPDF(I) = PDFwTnd(round(dataRT_forPDF(I)*1000))';
+                        if any(isnan(L_RT_PDW_fromPDF(I))); keyboard; end % TEMP
+
+                        %         I = Jdata & usetrs_data & data.PDW_preAlpha==0;
+                        I = Jdata & usetrs_data & data.PDW==0;
+                        n_RTlow_data(c) = sum(I);
+                        meanRTlow_data(m,c,d,h) = mean(data.RT(I));
+                        %         sigmaRTlow_data(m,c,d,h) = std(data.RT(I))/sqrt(sum(I)); % SD or SEM?
+                        %         sigmaRTlow_data_trialwise(Jdata) = sigmaRTlow_data(h); % copy to trials, for alternate LL calculation below
+
+                        % but we can just get the likelihood directly from the PDF!
+                        PDF = PxtBelowTheta/sum(PxtBelowTheta);
+                        PDFwTnd = conv(PDF,TndDist);
+                        PDFwTnd = PDFwTnd(1:length(P.t))/sum(PDFwTnd(1:length(P.t)));
+                        L_RT_PDW_fromPDF(I) = PDFwTnd(round(dataRT_forPDF(I)*1000))';
+                        if any(isnan(L_RT_PDW_fromPDF(I))); keyboard; end % TEMP
+
+                    end
+                end
+            end
         end
-        
-        meanRT_model(m,c,d,h) = pHB*P.up.mean_t(uh) + (1-pHB)*max_dur + Tnd; % weighted average
-        varRT_model(m,c,d,h)  = pHB*P.up.var_t(uh)  + (1-pHB)*0 + TndSD.^2; % TndSD?
- 
-        % for RT conditioned on wager, it seems we don't need to do any
-        % scaling by Ptb; the correct distribution is captured by the
-        % conditional Pxts, we just sum them, dot product w t and normalize
-        PxtAboveTheta = sum(Pxt1.*(logOddsMap>=theta(m))); % shouldn't matter if Pxt1 or 2, it's symmetric
-        PxtBelowTheta = sum(Pxt1.*(logOddsMap<theta(m)));
-        meanRThigh = PxtAboveTheta * R.t' / sum(PxtAboveTheta);
-        meanRTlow = PxtBelowTheta * R.t' / sum(PxtBelowTheta);
-        
-        % BUT these also need to factor in unabsorbed probability
-        % (ie weighted average with max_dur). Intuitively, we know that we    
-        % must scale pHB up for high bets, down for low bets. But I was
-        % unable to calculate the adjusted pHBs and gave up, for now (see
-        % old notes)
-        % Instead, just set both to pHB, which is close enough when pHB>.98
-        pHBhigh = pHB;
-        pHBlow = pHB;
-
-        meanRThigh_model(m,c,d,h) = pHBhigh*meanRThigh + (1-pHBhigh)*max_dur + Tnd;
-        meanRTlow_model(m,c,d,h) = pHBlow*meanRTlow + (1-pHBlow)*max_dur + Tnd;
-        
-        % copy to trials
-        RT_model_trialwise(Jdata) = meanRT_model(m,c,d,h);
-        RThigh_model_trialwise(Jdata) = meanRThigh_model(m,c,d,h);
-        RTlow_model_trialwise(Jdata) = meanRTlow_model(m,c,d,h);
-
-
-                % TEMP(?): compute the variances of these PDFs for the
-        % fitting-by-mean RT likelihood calculations below. This may become
-        % obsolete if we can use the PDFs themselves
-        
-        % variance = sum((x - mean).^2 .* y) 
-        % where x is the domain of the PDF, y is the PDF values over the
-        % domain x, and mean is the mean of the PDF, which you can
-        % calculate using the formula you provided: mean = sum(y.*x). -- thanks ChatGPT!
-
-% % %         % SJ 12-2022 Is diag is what we want here? Var(X) = E((X-E(X))^2)
-% % %         P.up.var_t = diag(P.up.pdf_t * ((R.t - P.up.mean_t).^2)' ./ P.up.p);
-% % %         P.lo.var_t = diag(P.lo.pdf_t * ((R.t - P.lo.mean_t).^2)' ./ P.lo.p);
-
-                                                                % ___note the PDFs are normalized___
-        sigmaRT_model(m,c,d,h) = sqrt(sum((R.t - P.up.mean_t(uh)).^2 .* P.up.pdf_t(uh,:)/sum(P.up.pdf_t(uh,:))));
-        sigmaRThigh_model(m,c,d,h) = sqrt(sum((R.t - meanRThigh).^2 .* PxtAboveTheta/sum(PxtAboveTheta)));
-        sigmaRTlow_model(m,c,d,h) = sqrt(sum((R.t - meanRTlow).^2 .* PxtBelowTheta/sum(PxtBelowTheta)));
-            % (note these do not include any variance added from convolution w Tnd dist)
-        sigmaRT_model_trialwise(Jdata) = sigmaRT_model(m,c,d,h);
-        sigmaRThigh_model_trialwise(Jdata) = sigmaRThigh_model(m,c,d,h);
-        sigmaRTlow_model_trialwise(Jdata) = sigmaRTlow_model(m,c,d,h);
-
-        
-        % grab the mean and sd(se?) for corresponding data
-        I = Jdata & usetrs_data;
-        n_RT_data(m,c,d,h) = sum(I);
-        meanRT_data(m,c,d,h) = mean(data.RT(I));
-        sigmaRT_data(m,c,d,h) = std(data.RT(I))/sqrt(sum(I)); % SD or SEM? --*obsolete even if not using full dists, use Sigma from the dist itself
-        sigmaRT_data_trialwise(Jdata) = sigmaRT_data(c); % copy to trials, for alternate LL calculation below
-                        % (should this be Jdata or I?)
-
-        % but we can just get the likelihood directly from the PDF!
-        PDF = P.up.pdf_t(uh,:)/sum(P.up.pdf_t(uh,:)); % renormalize
-        TndDist = normpdf(P.t,Tnd,2e-4)/sum(normpdf(P.t,Tnd,2e-4));
-        PDFwTnd = conv(PDF,TndDist); % convolve with ^Tnd dist (currently zero variance, approx something tiny)
-        PDFwTnd = PDFwTnd(1:length(P.t))/sum(PDFwTnd(1:length(P.t))); % normalize again and trim the extra length from conv
-        % figure;plot(PDF,'b');hold on; plot(PDFwTnd,'r'); % temp, just to see that the conv makes sense
-        L_RT_fromPDF(I) = PDFwTnd(round(dataRT_forPDF(I)*1000))';
-
-
-        % repeat for high/low
-%         I = Jdata & usetrs_data & data.PDW_preAlpha==1;
-        I = Jdata & usetrs_data & data.PDW==1;
-        n_RThigh_data(m,c,d,h) = sum(I);
-        meanRThigh_data(m,c,d,h) = mean(data.RT(I));
-%         sigmaRThigh_data(m,c,d,h) = std(data.RT(I))/sqrt(sum(I)); % SD or SEM?
-%         sigmaRThigh_data_trialwise(Jdata) = sigmaRThigh_data(h); % copy to trials, for alternate LL calculation below
-        
-        % but we can just get the likelihood directly from the PDF!
-        PDF = PxtAboveTheta/sum(PxtAboveTheta);
-        PDFwTnd = conv(PDF,TndDist);
-        PDFwTnd = PDFwTnd(1:length(P.t))/sum(PDFwTnd(1:length(P.t)));
-        L_RT_high_fromPDF(I) = PDFwTnd(round(dataRT_forPDF(I)*1000))';
-        if any(isnan(L_RT_high_fromPDF(I))); keyboard; end % TEMP
-
-        
-
-%         I = Jdata & usetrs_data & data.PDW_preAlpha==0;
-        I = Jdata & usetrs_data & data.PDW==0;
-        n_RTlow_data(c) = sum(I);
-        meanRTlow_data(m,c,d,h) = mean(data.RT(I));
-%         sigmaRTlow_data(m,c,d,h) = std(data.RT(I))/sqrt(sum(I)); % SD or SEM?
-%         sigmaRTlow_data_trialwise(Jdata) = sigmaRTlow_data(h); % copy to trials, for alternate LL calculation below
-        
-        % but we can just get the likelihood directly from the PDF!
-        PDF = PxtBelowTheta/sum(PxtBelowTheta);
-        PDFwTnd = conv(PDF,TndDist);
-        PDFwTnd = PDFwTnd(1:length(P.t))/sum(PDFwTnd(1:length(P.t)));
-        L_RT_low_fromPDF(I) = PDFwTnd(round(dataRT_forPDF(I)*1000))';
-        if any(isnan(L_RT_low_fromPDF(I))); keyboard; end % TEMP
-
     end
-
-end
-
-end
-end
 end
 
 % copy trial params to data struct 'fit', then replace data with model vals
@@ -547,37 +540,43 @@ fit = data;
 fit = rmfield(fit,'choice');
 try fit = rmfield(fit,'correct'); end %#ok<TRYNC>
 fit.pRight = pRight_model_trialwise;
-% fit.pRightHigh = pRightHigh_model_trialwise;
-% fit.pRightLow = pRightHigh_model_trialwise;
 
-if options.conftask==1 % SEP
-    fit.conf = conf_model_trialwise;
-    fit.PDW = nan(size(fit.conf));
-elseif options.conftask==2 % PDW
-    fit.conf = pHigh_model_trialwise;
-    fit.PDW = pHigh_model_trialwise; % legacy
-end
-if options.RTtask            
-    fit.RT = RT_model_trialwise;
-%     fit.RThigh = RThigh_model_trialwise;
-%     fit.RTlow = RTlow_model_trialwise;
+if R.lose_flag
+    fit.pRightHigh = pRightHigh_model_trialwise;
+    fit.pRightLow = pRightHigh_model_trialwise;
+
+    if options.conftask==1 % SEP
+        fit.conf = conf_model_trialwise;
+        fit.PDW = nan(size(fit.conf));
+    elseif options.conftask==2 % PDW
+        fit.conf = pHigh_model_trialwise;
+        fit.PDW = pHigh_model_trialwise; % legacy
+    end
+    if options.RTtask
+        fit.RT = RT_model_trialwise;
+        fit.RThigh = RThigh_model_trialwise;
+        fit.RTlow = RTlow_model_trialwise;
+    end
 end
 
 % also stored the 'parsed' values, for later plotting
 parsedFit = struct();
 parsedFit.pRight = pRight_model;
-if options.conftask==1 % SEP
-    parsedFit.confMean = meanConf_model;
-elseif options.conftask==2 % PDW
-    parsedFit.pHigh = pHigh_model;
-    parsedFit.pRightHigh = pRight_High_model;
-    parsedFit.pRightLow = pRight_Low_model;
-    parsedFit.pHighCorr = pHigh_Corr_model;
-    parsedFit.pHighErr = pHigh_Err_model;
+
+if R.lose_flag
+    if options.conftask==1 % SEP
+        parsedFit.confMean = meanConf_model;
+    elseif options.conftask==2 % PDW
+        parsedFit.pHigh = pHigh_model;
+        parsedFit.pRightHigh = pRight_High_model;
+        parsedFit.pRightLow = pRight_Low_model;
+        parsedFit.pHighCorr = pHigh_Corr_model;
+        parsedFit.pHighErr = pHigh_Err_model;
+    end
 end
 if options.RTtask
     parsedFit.RTmean = meanRT_model;
-    if options.conftask==2 % PDW
+    if options.conftask==2 && R.lose_flag % PDW
         parsedFit.RTmeanHigh = meanRThigh_model;
         parsedFit.RTmeanLow = meanRTlow_model;
     end
@@ -586,7 +585,7 @@ end
 
 %% Next, calculate error (negative log-likelihood) under binomial/gaussian assumptions
 
-% SJ 12-8-2022 this was missing before! Need choice to be 0..1
+% SJ 12-8-2022 this was missing before. LL calcs assume choice is 0..1
 if max(data.choice)==2
     data.choice = data.choice-1;
 end
@@ -596,81 +595,75 @@ choice = logical(data.choice);
 PDW    = logical(data.PDW);
 
 % to avoid log(0) issues:
-% minP = eps;
 minP = 1e-300;
-pRight_model_trialwise(pRight_model_trialwise==0) = minP; 
-pHigh_model_trialwise(pHigh_model_trialwise<=0) = minP; 
-
-% % % pRight_model_trialwise(pRight_model_trialwise==1) = 1-minP;
-% % % pHigh_model_trialwise(pHigh_model_trialwise>=1) = 1-minP;
-
+pRight_model_trialwise(pRight_model_trialwise==0) = minP;
 
 % CHOICE
 % log likelihood of rightward choice on each trial, under binomial assumptions:
-% LL_choice = sum(log(pRight_model_trialwise(choice))) + sum(log(1-pRight_model_trialwise(~choice)));
+LL_choice = sum(log(pRight_model_trialwise(choice))) + sum(log(1-pRight_model_trialwise(~choice)));
 
 
 % binomial over conditions, rather than bernoulli over trials
 % SJ 12-2022, I guess this is equivalent to above bernoulli
-L_choice = binopdf(nRight_data,nTrials,pRight_model); 
-L_choice(L_choice==0) = minP; % avoid log(0)
-LL_choice = nansum(log(L_choice(:)));
+% L_choice = binopdf(nRight_data,nTrials,pRight_model);
+% L_choice(L_choice==0) = minP; % avoid log(0)
+% LL_choice = nansum(log(L_choice(:)));
 
 % CHOICE, from conditionals
-pRight_Low_model_trialwise(pRight_Low_model_trialwise==0) = minP;
-pp = pRight_Low_model_trialwise(data.PDW==0); % conditionalize first
-cc = choice(data.PDW==0);
-LL_choice_low = sum(log(pp(cc))) + sum(log(1-pp(~cc)));
+% pRight_Low_model_trialwise(pRight_Low_model_trialwise==0) = minP;
+% pp = pRight_Low_model_trialwise(data.PDW==0); % conditionalize first
+% cc = choice(data.PDW==0);
+% LL_choice_low = sum(log(pp(cc))) + sum(log(1-pp(~cc)));
+%
+% pRight_High_model_trialwise(pRight_High_model_trialwise==0) = minP;
+% pp = pRight_High_model_trialwise(data.PDW==1); % conditionalize first
+% cc = choice(data.PDW==1);
+% LL_choice_high = sum(log(pp(cc))) + sum(log(1-pp(~cc)));
 
-pRight_High_model_trialwise(pRight_High_model_trialwise==0) = minP;
-pp = pRight_High_model_trialwise(data.PDW==1); % conditionalize first
-cc = choice(data.PDW==1);
-LL_choice_high = sum(log(pp(cc))) + sum(log(1-pp(~cc)));
-
-LL_choice_cond = LL_choice_low + LL_choice_high; % currently unused
+% LL_choice_cond = LL_choice_low + LL_choice_high; % currently unused
 
 % RT
 LL_RT = 0;
 % RT
-if options.RTtask     
-    
-%     sigmaRT_data = sigmaRT_data^2 % ***this seems more comparable to the theoretical SEM from Palmer, keep it as an option.
+if options.RTtask
 
-%     L_RToption = 'means_nosep';
-%     L_RToption = 'trials_nosep';
-%     L_RToption = 'means_sep';
-%     L_RToption = 'trials_sep';
+    %     sigmaRT_data = sigmaRT_data.^2 % ***this seems more comparable to the theoretical SEM from Palmer, keep it as an option.
+
+    %     L_RToption = 'means_nosep';
+    %     L_RToption = 'trials_nosep';
+    %     L_RToption = 'means_sep';
+    %     L_RToption = 'trials_sep';
     L_RToption = 'full_dist';
 
     switch L_RToption
         case 'means_nosep'
-            
+
             % Option 1a: means, not sep
             % (fit mean RTs for each coh under Gaussian approximation, NOT separated by high/low bet)
             L_RT = 1./(sigmaRT_model*sqrt(2*pi)) .* exp(-(meanRT_model-meanRT_data).^2 ./ (2*sigmaRT_model.^2)) / 1000; % div by 1000 to account for units (sec/ms)
-                    % *** NOT SURE ABOUT THE FACTOR OF 1000 ***
+            % *** NOT SURE ABOUT THE FACTOR OF 1000 ***
             L_RT(L_RT==0) = minP; % kluge to remove zeros, which are matlab's response to  exp(-[too large a number]), otherwise the log will give you infinity
             LL_RT = sum(log(L_RT(:))); % sum over all conditions (or trials)
-            LL_RT_high = NaN; LL_RT_low = NaN;
-            
+            %             LL_RT_high = NaN; LL_RT_low = NaN;
+
         case 'trials_nosep'
-    
+
             % Option 1b: trials, not sep
             % (assign means to trials and sum over those, to keep same order of mag as other LLs)
             I = usetrs_data;
             L_RT = 1./(sigmaRT_model_trialwise(I)*sqrt(2*pi)) .* exp(-(RT_model_trialwise(I) - data.RT(I)).^2 ./ (2*sigmaRT_model_trialwise(I).^2)) / 1000;
             L_RT(L_RT==0) = minP;
             LL_RT = sum(log(L_RT(:)));
-            LL_RT_high = NaN; LL_RT_low = NaN;
-            
+            %             LL_RT_high = NaN; LL_RT_low = NaN;
+
         case 'means_sep'
-    
+
             % Option 2a: means, sep hi/lo
             % (fit mean RT for each coherence, separately for high/low bet)
             L_RT_high = 1./(sigmaRThigh_model*sqrt(2*pi)) .* exp(-(meanRThigh_model-meanRThigh_data).^2 ./ (2*sigmaRThigh_model.^2)) / 1000;
             L_RT_high(L_RT_high==0) = minP;
-                % WEIGHT LL by nTrials, e.g. since there are fewer low bets
-                % at high coh, a miss there should penalize less
+            % WEIGHT LL by nTrials, e.g. since there are fewer low bets
+            % at high coh, a miss there should penalize less
             weightedLL = n_RThigh_data/sum(n_RThigh_data) .* log(L_RT_high) * length(cohs);
             LL_RT_high = sum(weightedLL);
 
@@ -680,104 +673,101 @@ if options.RTtask
             LL_RT_low = sum(weightedLL);
 
             LL_RT = LL_RT_high + LL_RT_low;
-            
+
         case 'trials_sep'
-    
+
             % Option 2b: trials, sep hi/lo
             % (separate by high/low bet and assign to trials, to keep order of mag)
-        %     I = usetrs_data & data.PDW_preAlpha==1; %??
+            %     I = usetrs_data & data.PDW_preAlpha==1; %??
             I = usetrs_data & data.PDW==1;
-            L_RT_high = 1./(sigmaRThigh_model_trialwise(I)*sqrt(2*pi)) .* exp(-(RThigh_model_trialwise(I) - data.RT(I)).^2 ./ (2*sigmaRThigh_model_trialwise(I).^2)) / 1000;    
+            L_RT_high = 1./(sigmaRThigh_model_trialwise(I)*sqrt(2*pi)) .* exp(-(RThigh_model_trialwise(I) - data.RT(I)).^2 ./ (2*sigmaRThigh_model_trialwise(I).^2)) / 1000;
             L_RT_high(L_RT_high==0) = minP;
             LL_RT_high = sum(log(L_RT_high));
-            
-        %     I = usetrs_data & data.PDW_preAlpha==0; %??
-            I = usetrs_data & data.PDW==0;    
+
+            %     I = usetrs_data & data.PDW_preAlpha==0; %??
+            I = usetrs_data & data.PDW==0;
             L_RT_low = 1./(sigmaRTlow_model_trialwise(I)*sqrt(2*pi)) .* exp(-(RTlow_model_trialwise(I) - data.RT(I)).^2 ./ (2*sigmaRTlow_model_trialwise(I).^2)) / 1000;
             L_RT_low(L_RT_low==0) = minP;
             LL_RT_low = sum(log(L_RT_low));
-            
-            LL_RT = LL_RT_high + LL_RT_low;
-            
-        case 'full_dist'
-            
-            % Option 3: fit full RT distributions            
-%             L_RT_fromPDF(L_RT_fromPDF==0) = minP;
-%             LL_RT = sum(log(L_RT_fromPDF)); % no need to use uncond
 
-            if sum(~isnan(L_RT_high_fromPDF))+sum(~isnan(L_RT_low_fromPDF)) ~= length(data.RT)
-                keyboard
-            end
-            L_RT_high_fromPDF(L_RT_high_fromPDF==0) = minP;
-            LL_RT_high = nansum(log(L_RT_high_fromPDF));
-            
-            L_RT_low_fromPDF(L_RT_low_fromPDF==0) = minP;
-            LL_RT_low = nansum(log(L_RT_low_fromPDF));
-                % these match the trialwise-by-means pretty well! reassuring.
-                
             LL_RT = LL_RT_high + LL_RT_low;
+
+        case 'full_dist'
+
+            % Option 3: fit full RT distributions
+            L_RT_fromPDF(L_RT_fromPDF==0) = minP;
+            LL_RT = sum(log(L_RT_fromPDF)); % no need to use uncond
+
+            if R.lose_flag
+%             L_RT_PDW_fromPDF(L_RT_PDW_fromPDF==0) = minP;
+%             LL_RT = nansum(log(L_RT_PDW_fromPDF));
+            end
+
     end
 
 end
 
 % CONF
-LL_conf = 0;
-if options.conftask==1 % SEP
-    
-    keyboard % this is unfinished
-    % likelihood of mean conf ratings for each condition, under Gaussian approximation
-    L_conf = 1./(sigmaConf_data*sqrt(2*pi)) .* exp(-(meanConf_model - meanConf_data).^2 ./ (2*sigmaConf_data.^2));
-    L_conf(L_conf==0) = min(L_conf(L_conf~=0));
-    LL_conf = nansum(log(L_conf(:))); % sum over all conditions
+if R.lose_flag
 
-elseif options.conftask==2 % PDW
+    LL_conf = 0;
+    if options.conftask==1 % SEP
 
-    % log likelihood of high bet on each trial, under binomial assumptions:
-%     LL_conf = sum(log(pHigh_model_trialwise(PDW))) + sum(log(1-pHigh_model_trialwise(~PDW)));
+        keyboard % this is unfinished
+        % likelihood of mean conf ratings for each condition, under Gaussian approximation
+        L_conf = 1./(sigmaConf_data*sqrt(2*pi)) .* exp(-(meanConf_model - meanConf_data).^2 ./ (2*sigmaConf_data.^2));
+        L_conf(L_conf==0) = min(L_conf(L_conf~=0));
+        LL_conf = nansum(log(L_conf(:))); % sum over all conditions
 
-    % CONF, from conditionals
-    pHigh_Corr_model_trialwise(pHigh_Corr_model_trialwise==0) = minP;
-    pp = pHigh_Corr_model_trialwise(data.correct==1); % conditionalize first
-    cc = PDW(data.correct==1);
-    LL_conf_corr = sum(log(pp(cc))) + sum(log(1-pp(~cc)));
-    
-    pHigh_Err_model_trialwise(pHigh_Err_model_trialwise==0) = minP;
-    pp = pHigh_Err_model_trialwise(data.correct==0); % conditionalize first
-    cc = PDW(data.correct==0);
-    LL_conf_err = sum(log(pp(cc))) + sum(log(1-pp(~cc)));
-    
-    LL_conf_cond = LL_conf_corr + LL_conf_err; % currently unused
+    elseif options.conftask==2 % PDW
+
+        % log likelihood of high bet on each trial, under binomial assumptions:
+        LL_conf = sum(log(pHigh_model_trialwise(PDW))) + sum(log(1-pHigh_model_trialwise(~PDW)));
+
+        % CONF, from conditionals
+        %     pHigh_Corr_model_trialwise(pHigh_Corr_model_trialwise==0) = minP;
+        %     pp = pHigh_Corr_model_trialwise(data.correct==1); % conditionalize first
+        %     cc = PDW(data.correct==1);
+        %     LL_conf_corr = sum(log(pp(cc))) + sum(log(1-pp(~cc)));
+        %
+        %     pHigh_Err_model_trialwise(pHigh_Err_model_trialwise==0) = minP;
+        %     pp = pHigh_Err_model_trialwise(data.correct==0); % conditionalize first
+        %     cc = PDW(data.correct==0);
+        %     LL_conf_err = sum(log(pp(cc))) + sum(log(1-pp(~cc)));
+        %
+        %     LL_conf_cond = LL_conf_corr + LL_conf_err; % currently unused
 
 
-    % CONF, binomial method
-    L_conf = binopdf(nHigh_data,nTrials,pHigh_model);
-    L_conf(L_conf==0) = minP;
-    LL_conf = nansum(log(L_conf(:)));
+        % CONF, binomial method
+        %     L_conf = binopdf(nHigh_data,nTrials,pHigh_model);
+        %     L_conf(L_conf==0) = minP;
+        %     LL_conf = nansum(log(L_conf(:)));
 
-   
-    % OR multinomial likelihood with n=1 and k=4 (categorial distribution)
-    RH = data.choice==1 & data.PDW==1;
-    RL = data.choice==1 & data.PDW==0;
-    LH = data.choice==0 & data.PDW==1;
-    LL = data.choice==0 & data.PDW==0;
-    LL_multinom = sum(log(max(pRightHigh_model_trialwise(RH),minP))) + sum(log(max(pRightLow_model_trialwise(RL),minP))) + ...
-                  sum(log(max(pLeftHigh_model_trialwise(LH),minP)))  + sum(log(max(pLeftLow_model_trialwise(LL),minP)));
 
-    % CONF multinomial, using mnpdf
-    % reorganize for mnpdf input (needs k cols, one per outcome)
-%     X = cat(5,nRightHigh_data,nRightLow_data,nLeftLow_data,nLeftHigh_data);
-%     P = cat(5,pRightHigh_model,pRightLow_model,pLeftLow_model,pLeftHigh_model);
-% 
-%     X(1,2,:,:,:) = NaN; % vestibular 'high' coh
-%     P(1,2,:,:,:) = NaN; % not strictly necessary but for consistency
-% 
-%     X = reshape(X,[],4);
-%     P = reshape(P,[],4);
-% 
-%     L_multinom = mnpdf(X,P);
-%     L_multinom(L_multinom==0) = minP;
-%     LL_multinom = nansum(log(L_multinom(:)));
+        % OR multinomial likelihood with n=1 and k=4 (categorial distribution)
+        RH = data.choice==1 & data.PDW==1;
+        RL = data.choice==1 & data.PDW==0;
+        LH = data.choice==0 & data.PDW==1;
+        LL = data.choice==0 & data.PDW==0;
+        LL_multinom = sum(log(max(pRightHigh_model_trialwise(RH),minP))) + sum(log(max(pRightLow_model_trialwise(RL),minP))) + ...
+            sum(log(max(pLeftHigh_model_trialwise(LH),minP)))  + sum(log(max(pLeftLow_model_trialwise(LL),minP)));
 
+        % CONF multinomial, using mnpdf
+        % reorganize for mnpdf input (needs k cols, one per outcome)
+        %     X = cat(5,nRightHigh_data,nRightLow_data,nLeftLow_data,nLeftHigh_data);
+        %     P = cat(5,pRightHigh_model,pRightLow_model,pLeftLow_model,pLeftHigh_model);
+        %
+        %     X(1,2,:,:,:) = NaN; % vestibular 'high' coh
+        %     P(1,2,:,:,:) = NaN; % not strictly necessary but for consistency
+        %
+        %     X = reshape(X,[],4);
+        %     P = reshape(P,[],4);
+        %
+        %     L_multinom = mnpdf(X,P);
+        %     L_multinom(L_multinom==0) = minP;
+        %     LL_multinom = nansum(log(L_multinom(:)));
+
+    end
 end
 
 % total -LL
@@ -785,9 +775,15 @@ end
 % OR
 % err = -(LL_choice + LL_conf);
 % OR
-err = -(LL_multinom + LL_RT);
+% err = -(LL_multinom + LL_RT);
 % OR
 %err = -LL_multinom;
+
+err = 0;
+
+for f = 1:length(options.whichFit)
+    err = err - eval(['LL_',options.whichFit{1}]);
+end
 
 
 % OR: fit choice and RT first, then hold those fixed to find theta
@@ -799,8 +795,8 @@ err = -(LL_multinom + LL_RT);
 if options.feedback
     fprintf('\n\n\n****************************************\n');
     fprintf('run %d\n', call_num);
-%     fprintf('\tkmult= %g\n\tB= %g\n\tthetaVes= %g\n\tthetaVis= %g\n\tthetaComb= %g\n\talpha= %g\n\tTndVes= %g\n\tTndVis= %g\n\tTndComb= %g\n', kmult, B, theta, alpha, Tnds(1),Tnds(2),Tnds(3));
-    
+    %     fprintf('\tkmult= %g\n\tB= %g\n\tthetaVes= %g\n\tthetaVis= %g\n\tthetaComb= %g\n\talpha= %g\n\tTndVes= %g\n\tTndVis= %g\n\tTndComb= %g\n', kmult, B, theta, alpha, Tnds(1),Tnds(2),Tnds(3));
+
     for p = 1:length(param)
         if ~fixed(p) % only print fitted parameter values
             fprintf('\t%s\t= %g\n',paramNames{p},param(p));
@@ -817,20 +813,20 @@ if options.feedback==2 && strcmp(options.fitMethod,'fms')
     drawnow;
 end
 call_num = call_num + 1;
-toc
+errFuncElapsed = toc(errFuncStart)
 
 
 %************
 % temp, diagnosing LL issues
-fprintf('\nLL_choice= %g\nLL_choice_low= %g\nLL_choice_high= %g\nLL_conf= %g\nLL_conf_corr= %g\nLL_conf_err= %g\nLL_multinom= %g\nLL_RT= %g\nLL_RT_low= %g\nLL_RT_high= %g\n', ...
-           LL_choice,     LL_choice_low,     LL_choice_high,     LL_conf,     LL_conf_corr,     LL_conf_err,     LL_multinom,     LL_RT,     LL_RT_low,     LL_RT_high);
+% fprintf('\nLL_choice= %g\nLL_choice_low= %g\nLL_choice_high= %g\nLL_conf= %g\nLL_conf_corr= %g\nLL_conf_err= %g\nLL_multinom= %g\nLL_RT= %g\n', ...
+%     LL_choice,     LL_choice_low,     LL_choice_high,     LL_conf,     LL_conf_corr,     LL_conf_err,     LL_multinom,     LL_RT   );
 %************
 
 end
 
 
-% retrieve the full parameter set given the adjustable and fixed parameters 
+% retrieve the full parameter set given the adjustable and fixed parameters
 function param2 = getParam ( param1 , guess , fixed )
-  param2(fixed==0) = param1(fixed==0);  %get adjustable parameters from param1
-  param2(fixed==1) = guess(fixed==1);   %get fixed parameters from guess
+param2(fixed==0) = param1(fixed==0);  %get adjustable parameters from param1
+param2(fixed==1) = guess(fixed==1);   %get fixed parameters from guess
 end

--- a/dots3DMP/behav_models/dots3DMP_fitDDM.m
+++ b/dots3DMP/behav_models/dots3DMP_fitDDM.m
@@ -1,4 +1,5 @@
-function [X, err_final, fit, parsedFit, fitInterp] = dots3DMP_fitDDM(data,options,guess,fixed)
+function X = dots3DMP_fitDDM(data,options,guess,fixed)
+%function [X, err_final, fit, parsedFit, fitInterp] = dots3DMP_fitDDM(data,options,guess,fixed)
 
 % parameter bounds for fitting
 
@@ -14,19 +15,13 @@ end
 PLB = guess/2;
 PUB = guess*2;
 
-% global call_num; call_num=1;
-% global paramVals; paramVals = guess';
-% global errVals; errVals = NaN;
-
-options.dummyRun = 0;
-
 if all(fixed)
     X = guess;
 else
     
     switch options.fitMethod
         case 'fms'
-            fitOptions = optimset('Display', 'iter', 'MaxFunEvals', 100*sum(fixed==0), 'MaxIter', ... 
+            fitOptions = optimset('Display', 'iter', 'PlotFcns', @optimplotfval, 'MaxFunEvals', 100*sum(fixed==0), 'MaxIter', ... 
                 100*sum(fixed==0), 'TolX',1e-1,'TolFun',1e-1,'UseParallel','Always');
             [X, fval, ~] = fminsearch(@(x) feval(options.errfcn,x,guess,fixed,data,options), guess(fixed==0), fitOptions);
     %         [X, fval, exitflag] = fminunc(@(x) feval(options.errfcn,x,guess,fixed,data,options), guess(fixed==0), fitOptions);
@@ -161,19 +156,22 @@ end
     
 %%
 
-% I think the interpFit part at least (and possibly all of this) should go
-% outside of this function...
+%{
+if 0
+    % SJ 02-2023 moved all this outside of this function
 
+% I think the interpFit part at least should go outside of this function,
+% as it's own call to the error function
+% e.g. a dots3DMP_evalDDM function which returns err and fit, the err_fin
 
 % run err func again at the fitted/fixed params to generate a final
 % error value and model-generated data points (trial outcomes)
 
-options.ploterr = 0;
+options.feedback = 0;
+options.dummyRun = 1;
 
 % override, the original, we are not really fitting here, but we want the
-% model predictions for all behavioral outcomes, even the ones we didn't use for fitting
-% or do we? then err_final is going to include LL from variables we didn't
-% use for fitting.
+% model predictions for all stimuli and behavioral outcomes, even the ones we didn't use for fitting
 options.whichFit  = {'multinom','RT'}; % choice, conf, RT, multinom (choice+conf)
 [err_final, fit, parsedFit] = feval(options.errfcn,X,X,true(size(X)),data,options);
 
@@ -232,5 +230,6 @@ else
     fitInterp = fit;
 end
 
-
+end
+%}
 

--- a/dots3DMP/behav_models/dots3DMP_fitDDM.m
+++ b/dots3DMP/behav_models/dots3DMP_fitDDM.m
@@ -1,4 +1,4 @@
-function [X, err_final, fit, fitInterp] = dots3DMP_fitDDM(data,options,guess,fixed)
+function [X, err_final, fit, parsedFit, fitInterp] = dots3DMP_fitDDM(data,options,guess,fixed)
 
 % parameter bounds for fitting
 
@@ -19,6 +19,8 @@ global call_num; call_num=1;
 global paramVals; paramVals = guess';
 global errVals; errVals = NaN;
 
+options.dummyRun = 0;
+
 if all(fixed)
     X = guess;
 else
@@ -26,14 +28,14 @@ else
     switch options.fitMethod
         case 'fms'
             fitOptions = optimset('Display', 'iter', 'MaxFunEvals', 100*sum(fixed==0), 'MaxIter', ... 
-                100*sum(fixed==0), 'TolX',1e-2,'TolFun',100,'UseParallel','Always');
+                100*sum(fixed==0), 'TolX',1e-3,'TolFun',1e-3,'UseParallel','Always');
             [X, fval, ~] = fminsearch(@(x) feval(options.errfcn,x,guess,fixed,data,options), guess(fixed==0), fitOptions);
     %         [X, fval, exitflag] = fminunc(@(x) feval(options.errfcn,x,guess,fixed,data,options), guess(fixed==0), fitOptions);
     %         fprintf('fval: %f\n', fval);
 
         case 'fmsbnd'
             fitOptions = optimset('Display', 'iter', 'MaxFunEvals', 100*sum(fixed==0), 'MaxIter', ... 
-                100*sum(fixed==0), 'TolX',1e-1,'TolFun',1e-1,'UseParallel','Always');
+                100*sum(fixed==0), 'TolX',1e-3,'TolFun',1e-3,'UseParallel','Always');
             [X, fval, ~] = fminsearchbnd(@(x) feval(options.errfcn,x,guess,fixed,data,options), guess(fixed==0), LB(fixed==0), UB(fixed==0), fitOptions);
 
         case 'global'
@@ -161,8 +163,8 @@ end
 %% run err func again at the fitted/fixed params to generate a final
 % error value and model-generated data points (trial outcomes)
 options.ploterr = 0;
-options.dummyRun = 0;
-[err_final, fit, ~, logOddsMap] = feval(options.errfcn,X,X,true(size(X)),data,options);
+
+[err_final, fit, parsedFit, logOddsMap] = feval(options.errfcn,X,X,true(size(X)),data,options);
 
 
 % THIS SHOULD ALL BECOME OBSOLETE, NO MORE MC!

--- a/dots3DMP/behav_models/dots3DMP_fitDDM.m
+++ b/dots3DMP/behav_models/dots3DMP_fitDDM.m
@@ -162,7 +162,7 @@ end
 % error value and model-generated data points (trial outcomes)
 options.ploterr = 0;
 options.dummyRun = 0;
-[err_final, fit] = feval(options.errfcn,X,X,true(size(X)),data,options);
+[err_final, fit, ~, logOddsMap] = feval(options.errfcn,X,X,true(size(X)),data,options);
 
 
 % THIS SHOULD ALL BECOME OBSOLETE, NO MORE MC!
@@ -214,6 +214,7 @@ end
 % [~,fitInterp] = dots3DMP_fitDDM_err(X,Dfit);
 fixed = true(size(X)); % fix all params
 options.dummyRun = 1;
+options.logOddsMap = logOddsMap;
 [~, fitInterp] = feval(options.errfcn,X,X,fixed,Dfit,options);
 
 else

--- a/dots3DMP/behav_models/dots3DMP_fitDDM.m
+++ b/dots3DMP/behav_models/dots3DMP_fitDDM.m
@@ -14,10 +14,9 @@ end
 PLB = guess/2;
 PUB = guess*2;
 
-global call_num; call_num=1;
-
-global paramVals; paramVals = guess';
-global errVals; errVals = NaN;
+% global call_num; call_num=1;
+% global paramVals; paramVals = guess';
+% global errVals; errVals = NaN;
 
 options.dummyRun = 0;
 
@@ -161,14 +160,22 @@ else
 end
     
 %%
+
+% I think the interpFit part at least (and possibly all of this) should go
+% outside of this function...
+
+
 % run err func again at the fitted/fixed params to generate a final
 % error value and model-generated data points (trial outcomes)
 
 options.ploterr = 0;
 
+% override, the original, we are not really fitting here, but we want the
+% model predictions for all behavioral outcomes, even the ones we didn't use for fitting
+% or do we? then err_final is going to include LL from variables we didn't
+% use for fitting.
 options.whichFit  = {'multinom','RT'}; % choice, conf, RT, multinom (choice+conf)
 [err_final, fit, parsedFit] = feval(options.errfcn,X,X,true(size(X)),data,options);
-
 
 % THIS SHOULD ALL BECOME OBSOLETE, NO MORE MC!
 if options.runInterpFit

--- a/dots3DMP/behav_models/dots3DMP_fitDDM.m
+++ b/dots3DMP/behav_models/dots3DMP_fitDDM.m
@@ -28,7 +28,7 @@ else
     switch options.fitMethod
         case 'fms'
             fitOptions = optimset('Display', 'iter', 'MaxFunEvals', 100*sum(fixed==0), 'MaxIter', ... 
-                100*sum(fixed==0), 'TolX',1e-3,'TolFun',1e-3,'UseParallel','Always');
+                100*sum(fixed==0), 'TolX',1e-1,'TolFun',1e-1,'UseParallel','Always');
             [X, fval, ~] = fminsearch(@(x) feval(options.errfcn,x,guess,fixed,data,options), guess(fixed==0), fitOptions);
     %         [X, fval, exitflag] = fminunc(@(x) feval(options.errfcn,x,guess,fixed,data,options), guess(fixed==0), fitOptions);
     %         fprintf('fval: %f\n', fval);
@@ -160,11 +160,14 @@ else
 
 end
     
-%% run err func again at the fitted/fixed params to generate a final
+%%
+% run err func again at the fitted/fixed params to generate a final
 % error value and model-generated data points (trial outcomes)
+
 options.ploterr = 0;
 
-[err_final, fit, parsedFit, logOddsMap] = feval(options.errfcn,X,X,true(size(X)),data,options);
+options.whichFit  = {'multinom','RT'}; % choice, conf, RT, multinom (choice+conf)
+[err_final, fit, parsedFit] = feval(options.errfcn,X,X,true(size(X)),data,options);
 
 
 % THIS SHOULD ALL BECOME OBSOLETE, NO MORE MC!
@@ -216,7 +219,6 @@ end
 % [~,fitInterp] = dots3DMP_fitDDM_err(X,Dfit);
 fixed = true(size(X)); % fix all params
 options.dummyRun = 1;
-options.logOddsMap = logOddsMap;
 [~, fitInterp] = feval(options.errfcn,X,X,fixed,Dfit,options);
 
 else

--- a/dots3DMP/behav_models/dots3DMP_fitDDM_wrapper.m
+++ b/dots3DMP/behav_models/dots3DMP_fitDDM_wrapper.m
@@ -19,7 +19,6 @@ load tempsim.mat
 
 % load lucio_20220301-20221006_clean
 
-
 %% some bookkeeping, then parse data, and plot if desired
 
 if ~exist('allowNonHB','var'); allowNonHB=0; end
@@ -51,7 +50,7 @@ end
 % plot it
 % dots3DMP_plots(parsedData,mods,cohs,deltas,hdgs,options.conftask,options.RTtask)
 
-% convert choice (back) to 0:1
+% convert choice (back) to 0...1, for fitting
 if max(data.choice(~isnan(data.choice)))==2
     data.choice = logical(data.choice-1);    
 end
@@ -70,24 +69,24 @@ modelID=1; options.errfcn = @dots3DMP_errfcn_DDM_2D_wConf_noMC; % 2D DDM aka ant
 % SJ 10/2021, no longer doing model fits via Monte Carlo
 options.runInterpFit = 1; 
 
-options.fitMethod = 'fms'; %'fms','global','multi','pattern','bads'
+options.fitMethod = 'multi'; %'fms','global','multi','pattern','bads'
 
-% guess = [origParams.kmult/100, origParams.B, origParams.theta, origParams.alpha, origParams.TndMean/1000];
-guess = [0.1, origParams.B, origParams.theta, origParams.alpha, origParams.TndMean/1000];
+guess = [origParams.kmult, origParams.B, origParams.theta, origParams.alpha, origParams.TndMean/1000];
+guess = guess.*rand(size(guess));
+% guess = [20, 1.5, origParams.theta, origParams.alpha, origParams.TndMean/1000];
 
 fixed = zeros(1,length(guess));
 
 % ************************************
 % set all fixed to 1 for hand-tuning, or 0 for full fit
-%fixed(:)=1;
+% fixed(:)=1;
 % ************************************
 
-fixed = [0 1 1 1 1 1 1 1 1];
+% fixed = [0 0 1 1 1 1 1 1 1];
 
 
 options.plot     = 0; % plot confidence maps
-options.feedback = 1; % plot error trajectory (prob doesn't work with parallel fit methods)
-
+options.feedback = 2; % plot error trajectory (prob doesn't work with parallel fit methods)
 options.useVelAcc = 0;
 
 %%
@@ -97,7 +96,7 @@ options.useVelAcc = 0;
 %% plot it!
 dots3DMP_plots_fit_byCoh(data,fitInterp,options.conftask,options.RTtask);
 
-% dots3DMP_plots_fit_byConf(data,parsedFit,options.conftask,options.RTtask);
+dots3DMP_plots_fit_byConf(data,parsedFit,options.conftask,options.RTtask);
 % incomplete
 
 %% in progress

--- a/dots3DMP/behav_models/dots3DMP_fitDDM_wrapper.m
+++ b/dots3DMP/behav_models/dots3DMP_fitDDM_wrapper.m
@@ -47,9 +47,9 @@ end
 
 % **** 
 % optional [data will be plotted below regardless, along with the fits]
-forTalk = 0;
+% forTalk = 0;
 % plot it
-dots3DMP_plots(parsedData,mods,cohs,deltas,hdgs,options.conftask,options.RTtask)
+% dots3DMP_plots(parsedData,mods,cohs,deltas,hdgs,options.conftask,options.RTtask)
 
 % convert choice (back) to 0:1
 if max(data.choice(~isnan(data.choice)))==2
@@ -64,10 +64,6 @@ end
 modelID=1; options.errfcn = @dots3DMP_errfcn_DDM_2D_wConf_noMC; % 2D DDM aka anticorrelated race, for RT+conf [Kiani 14 / van den Berg 16 (uses Wolpert's images_dtb_2d (method of images, from Moreno-Bote 2010))]
 %***********************************************
 
-% options.errfun = 'dots3DMP_fit_2Dacc_err_sepbounds_noMC';
-% options.errfun = 'dots3DMP_fit_2Dacc_err_singlebound_noMC_unsigned';
-options.errfun = 'dots3DMP_fit_2Dacc_err_singlebound_noMC_signed';
-
 % options.nreps  = 100;
 % options.confModel = 'evidence+time';
 
@@ -76,35 +72,40 @@ options.runInterpFit = 1;
 
 options.fitMethod = 'fms'; %'fms','global','multi','pattern','bads'
 
-guess = [origParams.kmult, origParams.B, origParams.theta, origParams.alpha, origParams.TndMean/1000];
+% guess = [origParams.kmult/100, origParams.B, origParams.theta, origParams.alpha, origParams.TndMean/1000];
+guess = [0.1, origParams.B, origParams.theta, origParams.alpha, origParams.TndMean/1000];
+
 fixed = zeros(1,length(guess));
 
 % ************************************
 % set all fixed to 1 for hand-tuning, or 0 for full fit
-fixed(:)=1;
+%fixed(:)=1;
 % ************************************
 
-% plot error trajectory (prob doesn't work with parallel fit methods)
-options.plot     = 0;
-options.feedback = 2;
+fixed = [0 1 1 1 1 1 1 1 1];
+
+
+options.plot     = 0; % plot confidence maps
+options.feedback = 1; % plot error trajectory (prob doesn't work with parallel fit methods)
+
+options.useVelAcc = 0;
 
 %%
-[X, err_final, fit, fitInterp] = dots3DMP_fitDDM(data,options,guess,fixed);
+[X, err_final, fit, parsedFit, fitInterp] = dots3DMP_fitDDM(data,options,guess,fixed);
 % fitInterp is in fact not obsolete, and needs fixing in ^^
 
-% plot it!
+%% plot it!
 dots3DMP_plots_fit_byCoh(data,fitInterp,options.conftask,options.RTtask);
 
+% dots3DMP_plots_fit_byConf(data,parsedFit,options.conftask,options.RTtask);
+% incomplete
 
 %% in progress
 
 % check for fit-then-predict (missing values for +/- delta, etc)
 
-if any(unique(fit.delta(isnan(fit.choice)))==0) %--> should be nonzeros only
-    keyboard
-end
+% if any(unique(fit.delta(isnan(fit.choice)))==0) %--> should be nonzeros only
+%     keyboard
+% end
 % this doesn't help, need to do the predict step in the fitDDM func
-
-
-
 

--- a/dots3DMP/behav_models/dots3DMP_fitDDM_wrapper.m
+++ b/dots3DMP/behav_models/dots3DMP_fitDDM_wrapper.m
@@ -17,7 +17,7 @@ load tempsim.mat
 
 %% or real data
 
-load lucio_20220301-20221006_clean
+% load lucio_20220301-20221006_clean
 
 
 %% some bookkeeping, then parse data, and plot if desired
@@ -75,13 +75,8 @@ options.errfun = 'dots3DMP_fit_2Dacc_err_singlebound_noMC_signed';
 options.runInterpFit = 1; 
 
 options.fitMethod = 'fms'; %'fms','global','multi','pattern','bads'
-% options.fitMethod = 'global';
-% options.fitMethod = 'multi';
-% options.fitMethod = 'pattern';
-% options.fitMethod = 'bads';
 
-guess = [origParams.kmult, origParam.B, origParams.theta,origParams.alpha, origParams.TndMean/1000]
-% fixed = [0 0 0 0 0 0 0 0 0];
+guess = [origParams.kmult, origParams.B, origParams.theta, origParams.alpha, origParams.TndMean/1000];
 fixed = zeros(1,length(guess));
 
 % ************************************
@@ -90,18 +85,15 @@ fixed(:)=1;
 % ************************************
 
 % plot error trajectory (prob doesn't work with parallel fit methods)
-options.ploterr  = 1;
-options.plot     = 1;
+options.plot     = 0;
 options.feedback = 2;
-
-if options.ploterr, options.fh = 400; end
 
 %%
 [X, err_final, fit, fitInterp] = dots3DMP_fitDDM(data,options,guess,fixed);
 % fitInterp is in fact not obsolete, and needs fixing in ^^
 
 % plot it!
-dots3DMP_plots_fit_byCoh(data,fitInterp,conftask,RTtask);
+dots3DMP_plots_fit_byCoh(data,fitInterp,options.conftask,options.RTtask);
 
 
 %% in progress

--- a/dots3DMP/behav_models/dots3DMP_fitDDM_wrapper.m
+++ b/dots3DMP/behav_models/dots3DMP_fitDDM_wrapper.m
@@ -5,73 +5,67 @@
 
 % TO DO
 
-% 
+% run fms fitting
+% plot splits by PDW after fitting
+% urgency version
+% post-fit confidence
+% move interpFit out of fitDDM
 
 
 clear; close all;
 addpath(genpath('/Users/stevenjerjian/Desktop/FetschLab/Analysis/codes/FLprojects/'))
 % addpath(genpath('/Users/stevenjerjian/Desktop/FetschLab/Analysis/codes/third-party-codes/WolpertMOI_collapse'))
 addpath(genpath('/Users/stevenjerjian/Desktop/FetschLab/Analysis/codes/third-party-codes/WolpertMOI'))
+addpath(genpath('/Users/stevenjerjian/Desktop/FetschLab/Analysis/codes/SJsandbox'))
 
 %% try fitting simulated data to recover the generative parameters
 
 cd /Users/stevenjerjian/Desktop/FetschLab/Analysis/data/dots3DMP_DDM
-load tempsim.mat
+load tempsim_sepConfMaps.mat
 
 %% or real data
 
 % load lucio_20220301-20221006_clean
 
-%% some bookkeeping, then parse data, and plot if desired
+%% set some vars
 
+% set allNonHB == 0 to ignore unabsorbed probability, ie no need for weighted sum with max_dur
+% in RT calculation, e.g. when sim excluded trials that failed to hit bound
 if ~exist('allowNonHB','var'); allowNonHB=0; end
 
-% ignore unabsorbed probability, ie no need for weighted sum with max_dur
-% in RT calculation, e.g. when sim excluded trials that failed to hit bound
-options.ignoreUnabs = ~allowNonHB;
+mods   = unique(data.modality);
+cohs   = unique(data.coherence);
+deltas = unique(data.delta);
 
 options.RTtask   = 1; 
 options.conftask = 2; % 1=continuous/rating, 2=PDW
 
-% parse trial data into aggregated and other support vars
-mods   = unique(data.modality);
-cohs   = unique(data.coherence);
-deltas = unique(data.delta);
-hdgs   = unique(data.heading);
 
-RTCorrOnly = 0;
-if ~exist('parsedData','var')  % e.g., if simulation was run
-    parsedData = dots3DMP_parseData(data,mods,cohs,deltas,hdgs,options.conftask,options.RTtask);
-end
+%% select model + options
 
-% **** 
-% optional [data will be plotted below regardless, along with the fits]
-% forTalk = 0;
-% dots3DMP_plots(parsedData,mods,cohs,deltas,hdgs,options.conftask,options.RTtask)
-
-% convert choice (back) to 0...1, for fitting
-if max(data.choice(~isnan(data.choice)))==2
-    data.choice = logical(data.choice-1);    
-end
-
-
-%% now the fitting itself
-
-%****** first select which model to fit ********
-modelID=1; options.errfcn = @dots3DMP_errfcn_DDM_2D_wConf_noMC; % 2D DDM aka anticorrelated race, for RT+conf [Kiani 14 / van den Berg 16 (uses Wolpert's images_dtb_2d (method of images, from Moreno-Bote 2010))]
-%***********************************************
-
-% options.nreps  = 100;
-% options.confModel = 'evidence+time';
-
-% SJ 10/2021, no longer doing model fits via Monte Carlo
-options.runInterpFit = 0; 
-
+% ==== method ====
+modelID=1; % unused for now
+options.errfcn    = @dots3DMP_errfcn_DDM_2D_wConf_noMC; % 2D DDM aka anticorrelated race, for RT+conf [Kiani 14 / van den Berg 16 (uses Wolpert's images_dtb_2d (method of images, from Moreno-Bote 2010))]
 options.fitMethod = 'fms'; %'fms','global','multi','pattern','bads'
+options.whichFit  = {'choice','RT'}; % choice, conf, RT, multinom (choice+conf)
+
+% ==== implementation ====
+options.dummyRun = 0;
+options.ignoreUnabs = ~allowNonHB;
+options.useVelAcc = 0; % use stimulus physical profiles in drift rates
+% options.confModel = 'evidence+time'; % unused for now
+
+% ==== diagnostics and output ====
+options.plot      = 0;      % plot confidence maps
+options.feedback  = 2;      % 0 - none, 1 - text feedback on LLs/err, 2 - plot errors vs. iteration #
+options.runInterpFit = 0;   % model predictions for interpolated headings? for nice plotting
+
+
+%% initialize parameters
 
 guess = [origParams.kmult, origParams.B, origParams.theta, origParams.alpha, origParams.TndMean/1000];
-% guess = guess.*(0.9+0.2.*rand(size(guess)));
-% guess = [20, 1.5, origParams.theta, origParams.alpha, origParams.TndMean/1000];
+
+guess = [35, 0.5, origParams.theta, origParams.alpha, origParams.TndMean/1000];
 
 fixed = zeros(1,length(guess));
 
@@ -80,30 +74,67 @@ fixed = zeros(1,length(guess));
 fixed(:)=1;
 % ************************************
 
-% fixed = [0 0 0 0 0 1 1 1 1];
+% or select some parameters to hold fixed
+fixed = [0 0 1 1 1 1 1 1 1];
 
 
-options.plot      = 0; % plot confidence maps
-options.feedback  = 2; % plot error trajectory (prob doesn't work with parallel fit methods)
-options.useVelAcc = 0;
-options.whichFit  = {'choice','RT'}; % choice, conf, RT, multinom (choice+conf)
+%% fit the model to data
 
-%%
-profile off;
-[X, err_final, fit, parsedFit, fitInterp] = dots3DMP_fitDDM(data,options,guess,fixed);
-% fitInterp is in fact not obsolete, and needs fixing in ^^
+X = dots3DMP_fitDDM(data,options,guess,fixed);
 
-%% plot it!
+%% evaluate fitted parameters at actual headings (get overall fit error)
+
+fixed = true(size(X)); % no actual fitting here
+
+% use all stimulus conditions (i.e. including delta), evaluate fit on all outcomes
+options.dummyRun = 0;
+options.whichFit = {'choice','conf','RT'}; % choice, conf, RT, multinom (choice+conf)
+
+options.feedback = 1;
+[err_final, fit, parsedFit] = feval(options.errfcn,X,X,fixed,data,options);
+
+%% plot the model predicted data points at this stage
+
+dots3DMP_plots_fit_byCoh(data,fit,options.conftask,options.RTtask);
+% dots3DMP_plots_fit_byConf(data,parsedFit,options.conftask,options.RTtask);
+
+%% hold initial fit params fixed, refit for others
+% e.g. we fit choice and RT, then come back for conf
+
+fixed = [1 1 0 0 0 0 1 1 1]; % thetas and alpha are free params
+options.whichFit = {'conf'}; % choice, conf, RT, multinom (choice+conf)
+
+options.feedback = 2;
+[err_final, fit, parsedFit] = feval(options.errfcn,X,X,fixed,data,options);
+
+if options.runInterpFit
+
+    fixed = true(size(X)); % again, no actual fitting
+
+    % generate smooth fit curve with simulated linspaced headings
+    hdgs = linspace(min(data.heading),max(data.heading),33); % odd so that there's a zero
+
+    % Dfit is a dummy dataset with the same proportions of all trial types,
+    [Dfit.heading, Dfit.modality, Dfit.coherence, Dfit.delta, ~] = dots3DMP_create_trial_list(hdgs,mods,cohs,deltas,1,0);
+
+    % and the observables are just placeholders because we don't care about error
+    % here, we just want the model predictions from fixed parameters
+    Dfit.choice  = ones(size(Dfit.heading));
+    Dfit.RT      = ones(size(Dfit.heading));
+    Dfit.conf    = ones(size(Dfit.heading));
+    Dfit.PDW     = ones(size(Dfit.heading));
+    Dfit.correct = ones(size(Dfit.heading));
+
+    % now calculate the interpolated fit
+    [~, fitInterp] = feval(options.errfcn,X,X,fixed,Dfit,options);
+else
+    fitInterp = fit; % placeholder
+end
+
+%% plot the model predicted data points again now
+
 dots3DMP_plots_fit_byCoh(data,fitInterp,options.conftask,options.RTtask);
+% dots3DMP_plots_fit_byConf(data,parsedFit,options.conftask,options.RTtask);
 
-dots3DMP_plots_fit_byConf(data,parsedFit,options.conftask,options.RTtask);
 
-%% in progress
-
-% check for fit-then-predict (missing values for +/- delta, etc)
-
-% if any(unique(fit.delta(isnan(fit.choice)))==0) %--> should be nonzeros only
-%     keyboard
-% end
-% this doesn't help, need to do the predict step in the fitDDM func
 

--- a/dots3DMP/behav_models/dots3DMP_simDDM_2D.m
+++ b/dots3DMP/behav_models/dots3DMP_simDDM_2D.m
@@ -8,12 +8,17 @@
 
 %% build expt and hand-pick some model params
 
+% at some point, build these settings out into a proper wrapper script
+
 clear; close all
 
 % datafolder = '/Users/chris/Documents/MATLAB';
 % codefolder = '/Users/chris/Documents/MATLAB/Projects/offlineTools/dots3DMP/behav_models';
 
-% cd(codefolder)
+datafolder = '/Users/stevenjerjian/Desktop/FetschLab/Analysis/data/dots3DMP_DDM';
+codefolder = '/Users/stevenjerjian/Desktop/FetschLab/Analysis/codes/FLprojects/dots3DMP/behav_models';
+
+cd(codefolder)
 
 modelID  = 1; % 1 will be 2Dacc model ('Candidate model' against which others are tested).
 modelVar = 1; % variation within model ID, e.g. velocity acceleration coding, confidence model, cue weighting in combined..
@@ -22,7 +27,6 @@ modelVar = 1; % variation within model ID, e.g. velocity acceleration coding, co
 % these will be obsolete with modelVar eventually
 confModel = 'evidence+time'; % 'evidence+time','evidence_only','time_only'
 useVelAcc = 1; 
-
 
 RTtask = 1;
 conftask = 2; % 1 - sacc endpoint, 2 - PDW
@@ -73,25 +77,25 @@ if useVelAcc
     acc = acc/max(abs(acc));
     acc(acc<0) = 0; % hmm
 
-% step functions
+% step functions, for testing param recovery and LL comparisons
 %     acc = [zeros(max_dur/2,1); ones(max_dur/2,1)];
 %     vel = [ones(max_dur/2,1); zeros(max_dur/2,1)];
 
 
-    if useVelAcc==1 
+    if useVelAcc==1 % ves follow acc, vis follows vel
         sves = acc; svis = vel;
     elseif useVelAcc==2 % both vel
         sves = vel; svis = vel;
     elseif useVelAcc==3 % both acc
         sves = acc; svis = acc; 
     end
-else
+else % or fixed, i.e. no vel/acc weighting
     sves = ones(1,max_dur);
     svis = sves;
 end
 
 %% PARAMS - these are things we will actually fit!
-
+% also maybe move this to wrapper script
 
 kmult = 150; % drift rate multiplier
 kvis  = kmult*cohs; % assume drift proportional to coh, reduces nParams
@@ -368,19 +372,20 @@ pHitBound_zeroHdg = sum(hitBound(Z))/sum(Z)
 choice(choice==0) = sign(randn)*eps; % should have no actual zeros, but if so, sign them randomly;
                                % this is just to assign a direction and correct/error
 choice(choice==1) = 2; choice(choice==-1) = 1; % 1=left, 2=right
-data.modality = modality;
-data.heading = hdg;
-data.coherence = coh;
-data.delta = delta;
-data.choice = choice;
-data.RT = RT/1000; % change to seconds
-data.conf = conf;
-data.PDW = pdw;
-data.PDW_preAlpha = pdw_preAlpha;
-data.correct = correct;
-subject = 'simul';
 
-data.oneTargConf=false(size(hdg));
+data.modality   = modality;
+data.heading    = hdg;
+data.coherence  = coh;
+data.delta      = delta;
+data.choice     = choice;
+data.RT         = RT/1000; % change to seconds
+data.conf       = conf;
+data.PDW        = pdw;
+data.PDW_preAlpha = pdw_preAlpha;
+data.correct    = correct;
+subject         = 'simul';
+
+data.oneTargConf = false(size(data.heading));
 
 %% plots
 if 1

--- a/dots3DMP/behav_models/dots3DMP_simDDM_2D.m
+++ b/dots3DMP/behav_models/dots3DMP_simDDM_2D.m
@@ -115,7 +115,7 @@ R.t = dT/1000:dT/1000:max_dur/1000;
 R.Bup = B;
 R.drift = k * sind(hdgs(hdgs>=0)); % takes only unsigned drift rates
 R.lose_flag = 1;
-R.plotflag = 0; % 1 = plot, 2 = plot and export_fig
+R.plotflag = 1; % 1 = plot, 2 = plot and export_fig
 P = images_dtb_2d(R);
 
 %% simulate bounded evidence accumulation

--- a/dots3DMP/dots3DMP_parseData_byConf.m
+++ b/dots3DMP/dots3DMP_parseData_byConf.m
@@ -9,6 +9,11 @@ function parsedData = dots3DMP_parseData_byConf(data,mods,cohs,deltas,hdgs,conft
 if nargin < 7, RTtask = 0; end
 if conftask == 0, error('Cannot split data by confidence for non-conf task!'); end
 
+% switch back to 1:2 if 0:1 (e.g. from fitting code)
+if max(data.choice)==1
+    data.choice = data.choice+1;
+end
+
 %% parse data
 % create and use matrices of summary data indexed by variables of interest
 

--- a/dots3DMP/images_dtb_2d_varDrift.m
+++ b/dots3DMP/images_dtb_2d_varDrift.m
@@ -1,0 +1,230 @@
+function P =  images_dtb_2d_varDrift(R)
+
+% P =  images_dtb_2d_varDrift(R)
+% Method of images solution to bounded drift diffusion of two races with
+% correlated (-1/sqrt(0.5)) noise  i.e.  2D drift to bound.
+% The winner of the race is the one that reaches its upper bound first
+% There is  no lower bound and the bounds are flat
+% the grid size (ngrid) for simulation is set at 500 in DV space but can be changed
+%
+%
+% ~~~~~~~~~~~~~~~
+% Inputs is a structure R (all in SI units)
+% drift:      vector of drift rates [length ndrift]
+% vardrift:   matrix of drift rates [ndrift x nt]
+% t:          vector time series to simulate [length nt]
+% Bup:        bound height [scalar]
+% lose_flag:  whether we want the losing densities as well (slower)
+%
+% drift_freq: frequencies of each drift rate (stimulus strength) in the data, for calculation of marginals - CF
+% plotflag:   make some plots (or not) [1 = plot, 2 = plot and save] - CF
+
+% ~~~~~~~~~~~~~~~
+% Outputs:  a structure P (which includes the inputs as well)
+% P.up and P.lo (for two bounds) contains
+%       pdf_t:  pdf of the winner [ndrift x nt]
+%       cdf_t:  cdf of the winner [ndrift x nt]
+%       p:  total prob up/lo  [ndrift]
+%       mean_t:  mean time of up/lo [ndrift]
+%       distr_loser: pdf of the losing race [ndrift x nt x ngrid ]
+% y:    dv values of grid (bounds are at zero and intial dv is -Bup) [ngrid]
+% dy:   grid spacing
+% 
+% logOddsCorrMap: log posterior odds of a correct response,
+% as a function of state of losing accumulator (Kiani 2014) -- CF
+%
+% SJ 11/2022 drift rate as matrix to allow time-varying
+
+
+if ~isfield(R,'lose_flag')
+    R.lose_flag=0;
+end
+if ~isfield(R,'plotflag')
+    R.plotflag=0;
+end
+if ~isfield(R,'vardrift')
+    R.vardrift = repmat(R.drift(:),1,length(R.t));
+end
+P=R; % copy inputs to outputs
+
+
+ndrift=length(R.drift); %number of drifts
+nt=length(R.t); %number of time points to simulate
+ngrid=500; %grid size can change
+
+dt=R.t(2)-R.t(1); %sampling interval
+
+% g=linspace(-7,0,ngrid);  %dv values can change lower
+g=linspace(-4*R.Bup,0,ngrid); % CF: why hard-coded as -7? try 4x bound
+
+dg=g(2)-g(1); %grid spacing
+
+%  pdf of the losing races if needed
+if R.lose_flag
+    P.up.distr_loser = zeros(ndrift,nt,ngrid);
+    P.lo.distr_loser = zeros(ndrift,nt,ngrid);
+end
+
+for id=1:ndrift %loop over drifts
+    for k=2:nt  %loop over time starting at t(2)
+        if R.lose_flag
+            [P.up.pdf_t(id,k) P.lo.pdf_t(id,k) P.up.distr_loser(id,k,:) P.lo.distr_loser(id,k,:)]...
+                = flux_img7(R.Bup,R.vardrift(id,k),R.t(k),g,g);
+        else
+            [P.up.pdf_t(id,k) P.lo.pdf_t(id,k) ]=flux_img7(R.Bup,R.vardrift(id,k),R.t(k),g,g); %#ok<*NCOMMA>
+        end
+    end
+end
+P.up.pdf_t= P.up.pdf_t*dt;
+P.lo.pdf_t= P.lo.pdf_t*dt;
+
+if R.lose_flag %put any missing density into the most negative bin
+    P.up.distr_loser = P.up.distr_loser*dg*dt;
+    P.lo.distr_loser = P.lo.distr_loser*dg*dt;
+    
+    P.up.distr_loser(:,:,1)= P.up.pdf_t- nansum(P.up.distr_loser(:,:,2:end),3);
+    P.lo.distr_loser(:,:,1)= P.lo.pdf_t- nansum(P.lo.distr_loser(:,:,2:end),3);
+end
+
+P.up.cdf_t = cumsum(P.up.pdf_t,2);
+P.lo.cdf_t = cumsum(P.lo.pdf_t,2);
+
+P.up.p = P.up.cdf_t(:,end);
+P.lo.p = P.lo.cdf_t(:,end);
+
+try
+    P.up.mean_t = P.up.pdf_t * R.t  ./P.up.p;
+    P.lo.mean_t = P.lo.pdf_t * R.t  ./P.lo.p;
+catch
+    P.up.mean_t = P.up.pdf_t * R.t'  ./P.up.p;
+    P.lo.mean_t = P.lo.pdf_t * R.t'  ./P.lo.p;
+end
+
+P.y=g;
+P.dy=dg;
+
+
+% CF: log posterior odds of a correct response (Eq. 3 in Kiani et al. 2014)
+I = R.drift>=0; % In case drift is signed, calculate only for positives,
+                % then the kluge with separate marginals (Pxt's) can be done elsewhere
+% unlike 1D code, here we'll marginalize over drift in one step               
+odds = (squeeze(sum(P.up.distr_loser(I,:,:),1)) / length(R.drift(I))) ./ ...
+       (squeeze(sum(P.lo.distr_loser(I,:,:),1)) / length(R.drift(I)));
+odds(odds<1) = 1; % fix some stray negatives/zeros (what about infs?)
+odds(isinf(odds)) = nan;
+P.logOddsCorrMap = log(odds);
+P.logOddsCorrMap = P.logOddsCorrMap';
+
+
+% % alternative, modeled after 1D (Kiani09,certstim) code:
+% Pxt_marginal = zeros(ngrid, nt, 2); % xmesh * time * motion_direction
+% for id=1:ndrift %loop over drifts
+%     F = R.drift_freq(id);
+%     Pxt = squeeze(P.up.distr_loser(id,:,:))';
+%     Pxt_marginal(:,:,1) = Pxt_marginal(:,:,1) + F*Pxt; % xmesh * time
+% 
+%     Pxt = squeeze(P.lo.distr_loser(id,:,:))';
+%     Pxt_marginal(:,:,2) = Pxt_marginal(:,:,2) + F*Pxt; % xmesh * time
+% end
+% % odds = (Pxt_marginal(:,:,2)./Pxt_marginal(:,:,1));
+% odds = (Pxt_marginal(:,:,1)./Pxt_marginal(:,:,2));
+% odds(odds<1) = 1; % fix some stray negatives/zeros (what about infs?)
+% odds(isinf(odds)) = nan;
+% P.logOddsCorrMap = log(odds);
+%     %^ not strictly identical, off by a total of ~0.27, but close enough(?)
+
+
+% okay, well, maybe we need both R and L (even for unsigned?)
+    % R/corr
+I = R.drift>=0; % In case drift is signed, calculate only for positives,
+                % then the kluge with separate marginals (Pxt's) can be done elsewhere
+odds = (squeeze(sum(P.up.distr_loser(I,:,:),1)) / length(R.drift(I))) ./ ...
+       (squeeze(sum(P.lo.distr_loser(I,:,:),1)) / length(R.drift(I)));
+odds(odds<1) = 1; % fix some stray negatives/zeros (what about infs?)
+P.logOddsCorrMapR = log(odds);
+P.logOddsCorrMapR = P.logOddsCorrMapR';
+    % L/incorr
+odds = (squeeze(sum(P.lo.distr_loser(I,:,:),1)) / length(R.drift(I))) ./ ...
+       (squeeze(sum(P.up.distr_loser(I,:,:),1)) / length(R.drift(I)));
+odds(odds<1) = 1; % fix some stray negatives/zeros (what about infs?)
+P.logOddsCorrMapL = log(odds);
+P.logOddsCorrMapL = P.logOddsCorrMapL';
+
+
+% % % % from 1D code:
+% % % I = xmesh>0;
+% % % logPosteriorOddsRight = log(Pxt_marginal(I,:,1)./Pxt_marginal(I,:,2));
+% % % bet_high_xt(I,:) = logPosteriorOddsRight > theta;
+% % % I = xmesh<0;
+% % % logPosteriorOddsLeft = log(Pxt_marginal(I,:,2)./Pxt_marginal(I,:,1));
+% % % bet_high_xt(I,:) = logPosteriorOddsLeft > theta2;
+
+
+if R.plotflag
+
+    % (1) plot choice and RT
+    figure(111); set(gcf,'Color',[1 1 1],'Position',[600 600 450 700],'PaperPositionMode','auto'); clf;
+    subplot(3,1,1); plot(R.drift,P.up.p,'o-'); title('Prob correct bound crossed before tmax') % meaningless w signed drift
+    subplot(3,1,2); plot(R.drift,P.up.p./(P.up.p+P.lo.p),'o-'); title('Relative prob of corr vs. incorr bound crossed (Pcorr)'); % actually pRight with signed drift
+    subplot(3,1,3); plot(R.drift,P.up.mean_t,'o-'); title('mean RT'); xlabel('drift rate');
+
+    % remake Fig. 5c-d of Kiani et al 2014 (steps analogous to makeLogOddsCorrMap_*)
+    n = 100; % set n to 100+ for smooth plots, lower for faster plotting
+    
+    % (2) first an example PDF
+    c = round(length(R.drift(I))/2) - 1 + sum(I==0); % pick an intermediate drift rate, or make a loop to see all of them
+    q = 30; % exponent for log cutoff (redefine zero as 10^-q, for better plots
+%     Pmap = squeeze(P.up.distr_loser(c,:,:))';
+    Pmap = squeeze(P.lo.distr_loser(c,:,:))';
+    Pmap(Pmap<10^-q) = 10^-q;
+    logPmap = (log10(Pmap)+q)/q;
+
+    figure(c*100); set(gcf, 'Color', [1 1 1], 'Position', [200 300 500 850/R.plotflag], 'PaperPositionMode', 'auto');
+    if R.plotflag==1; subplot(2,1,1); end
+    [~,h] = contourf(R.t,P.y,logPmap,n); colormap(jet);
+    caxis([0 1]); % because we log transformed such that 10^-q is 0 and 1 is 1
+    colorbar('YTick',0:.2:1,'YTickLabel',{['10^-^{' num2str(q) '}']; ['10^-^{' num2str(q*.8) '}']; ['10^-^{' num2str(q*.6) '}']; ['10^-^{' num2str(q*.4) '}']; ['10^-^{' num2str(q*.2) '}']; '1'}); 
+        % manually, for now:
+%     colorbar('YTick',0:.2:1,'YTickLabel',{'10^-^5^0'; '10^-^4^0'; '10^-^3^0'; '10^-^2^0'; '10^-^1^0'; '1'}); 
+    set(gca,'XLim',[0 R.t(end)],'XTick',0:0.5:floor(R.t(end)*2)/2,'TickDir','out');
+%     set(gca,'YLim',[-4*R.Bup 0],'YTick',floor(-4*R.Bup):round(R.Bup*2)/2:0); 
+    set(gca,'YLim',[-2*R.Bup 0],'YTick',-2*R.Bup:R.Bup/2:0,'YtickLabel',{num2str(-R.Bup) '' '0' '' num2str(R.Bup)});
+    set(h,'LineColor','none');
+    xlabel('Time (s)'); ylabel('Accumulated evidence of losing accumulator');
+    title('Probability density of losing accumulator');
+    changeAxesFontSize(gca,15,15);
+    if R.plotflag==2
+        ylim([-2.5 0]);
+        xlabel([]);ylabel([]);title([]);
+        changeAxesFontSize(gca,24,24);
+        export_fig('2dacc_PDF','-eps');
+    end
+        
+    % (3) then the log odds corr map
+    if R.plotflag==1
+        subplot(2,1,2);
+    else
+        figure(c*1000); set(gcf, 'Color', [1 1 1], 'Position', [700 400 450 700/R.plotflag], 'PaperPositionMode', 'auto');
+    end
+    [~,h] = contourf(R.t,P.y,P.logOddsCorrMap,n); colormap(parula);
+    caxis([0 3]);
+    colorbar('YTick',0:0.5:3); 
+    set(gca,'XLim',[0 R.t(end)],'XTick',0:0.5:floor(R.t(end)*2)/2,'TickDir','out');
+%     set(gca,'YLim',[-4*R.Bup 0],'YTick',floor(-4*R.Bup):round(R.Bup*2)/2:0); 
+    set(gca,'YLim',[-2*R.Bup 0],'YTick',-2*R.Bup:R.Bup/2:0,'YtickLabel',{num2str(-R.Bup) '' '0' '' num2str(R.Bup)});
+    set(h,'LineColor','none');
+    xlabel('Time (s)'); ylabel('Accumulated evidence of losing accumulator');
+    title('Log odds correct vs. state of losing accumulator');
+    changeAxesFontSize(gca,15,15);
+    
+    if R.plotflag==2
+        ylim([-2.5 0])
+        xlabel([]);ylabel([]);title([]);
+        changeAxesFontSize(gca,24,24);
+        export_fig('2dacc_logoddscorr','-eps')
+    end
+
+end
+
+
+

--- a/dots3DMP/plotting/dots3DMP_plots_fit_byConf.m
+++ b/dots3DMP/plotting/dots3DMP_plots_fit_byConf.m
@@ -201,18 +201,13 @@ catch
     parsedFit = fit;
 end
 
-
-% plot it!
-
-% first, single-cues + zero-delta comb
-
 %ves %vis %comb
 % clr{1} = {'k-','m-','c-'};
 clr{1} = {'k-','r-','b-'};
 clr{2} = {'k-','r-','b-'};
 clr{3} = {'k-','y-','g-'};
 
-hdgs = linspace(-12,12,33);
+% hdgs = linspace(-12,12,33);
 figure(101);
 for c = 1:length(cohs)
     subplot(spRows,length(cohs),c);

--- a/dots3DMP/plotting/dots3DMP_plots_fit_byConf.m
+++ b/dots3DMP/plotting/dots3DMP_plots_fit_byConf.m
@@ -1,0 +1,264 @@
+function dots3DMP_plots_fit_byConf(data,fit,conftask,RTtask)
+% similar to dots3DMP_plots_fit_byCoh, but for different confidence levels
+
+% calls parseData on struct data and plots just the data points, then does
+% the analogous step for struct fit, and plots the result as lines (interp)
+%   [CF removed fitGauss as it should be obsolete with non-MC]
+
+if nargin<3, conftask=2; end
+if nargin<4, RTtask = 0; end
+
+fsz = 14; % fontsize
+
+mods   = unique(data.modality);
+cohs   = unique(data.coherence);
+deltas = unique(data.delta);
+hdgs   = unique(data.heading);
+
+if ~isfield(data,'oneTargConf')
+    data.oneTargConf = false(size(data.heading));
+end
+
+if all(mods==1), cohs=1; end
+
+xLab = sprintf('heading angle (%s)',char(176));
+modlabels = {'Ves','Vis','Comb'};
+
+if conftask==1 
+    yLab = 'SaccEP'; confYlims = [0.2 0.9]; 
+    if all(mods==1), RTylims = [0.9 1.5]; 
+    else,            RTylims = [0.9 1.9]; 
+    end
+    xt = -10:5:10;
+     if length(mods)>1, cohlabs = {'Low Coh','High Coh'}; end
+elseif conftask==2
+    yLab = 'P(High Bet)'; confYlims = [0.4 1.0]; 
+    if all(mods==1), RTylims = [0.5 0.72]; 
+    else,            RTylims = [0.5 0.9]; 
+    end
+    xt = -12:6:12;
+    if length(mods)>1, cohlabs = {['coh = ' num2str(cohs(1))],['coh = ' num2str(cohs(2))]}; end
+end 
+
+%% actual data
+% plot as individual points with error bars
+
+useAbsHdg = 0;
+RTCorrOnly = 1; % when fitting correct RTs only, only compare to those in the data
+
+parsedData = dots3DMP_parseData_byConf(data,mods,cohs,deltas,hdgs,conftask,RTtask);
+
+if useAbsHdg
+    hdgs = unique(abs(hdgs));
+end
+
+spRows = 1 + double(RTtask);
+
+% first, single-cues + zero-delta comb
+D = find(deltas==0);
+         %ves %vis %comb
+% clr{1} = {'ko','mo','co'};
+clr{1} = {'ko','ro','bo'};
+clr{2} = {'ko','ro','bo'};
+clr{3} = {'ko','yo','go'};
+figure(101);
+set(gcf,'Color',[1 1 1],'Position',[300 1000 230+300*(length(cohs)-1) 200+150*(conftask>0)+150*RTtask],'PaperPositionMode','auto'); clf;
+for c = 1:length(cohs)
+    subplot(spRows,length(cohs),c); hold on;
+    for m = 1:length(mods)     % m c d h
+        h(m,1) = plot(hdgs, squeeze(parsedData.pRight(m,c,D,:,1)), clr{c}{m},'linewidth',1.5,'linestyle','none');
+        h(m,2) = plot(hdgs, squeeze(parsedData.pRight(m,c,D,:,2)), clr{c}{m}(1),'linewidth',1.5,'linestyle','none','marker','x');
+    end
+    
+    if RTtask
+        subplot(spRows,length(cohs),c+length(cohs)); hold on
+        for m = 1:length(mods)
+%             h(m) = errorbar(hdgs, squeeze(parsedData.RTmean(m,c,D,:)), squeeze(parsedData.RTse(m,c,D,:)), [clr{c}{m}],'linewidth',1.5); 
+
+
+            plot(hdgs, squeeze(parsedData.RTmean(m,c,D,:,1)), clr{c}{m}(1),'linestyle','none','linewidth',1.5,'marker',clr{c}{m}(2));
+            plot(hdgs, squeeze(parsedData.RTmean(m,c,D,:,2)), clr{c}{m}(1),'linestyle','none','linewidth',1.5,'marker','x');
+        
+        end
+    end
+    
+end
+
+% now comb separated by delta
+if length(deltas)>1
+
+clr{1} = {'bs','cs','gs'};
+clr{2} = {'b^','c^','g^'};
+clr{3} = {'bo','co','go'};
+
+clear L;
+figure(108);
+set(gcf,'Color',[1 1 1],'Position',[50 20 230+300*(length(cohs)-1) 200+150*(conftask>0)+150*RTtask],'PaperPositionMode','auto'); clf;
+for c = 1:length(cohs)
+    subplot(spRows,length(cohs),c); hold on
+    for d = 1:length(deltas)     % m c d h
+        h(d) = errorbar(hdgs, squeeze(parsedData.pRight(3,c,d,:)), squeeze(parsedData.pRightSE(3,c,d,:)), [clr{c}{d}],'linewidth',1.5);
+%         L{d} = sprintf('\x0394=%d',deltas(d));
+    end
+
+    if conftask>0
+        subplot(spRows,length(cohs),c+length(cohs)); hold on
+        for d = 1:length(deltas)
+            h(d) = errorbar(hdgs, squeeze(parsedData.confMean(3,c,d,:)), squeeze(parsedData.confSE(3,c,d,:)), [clr{c}{d}],'linewidth',1.5);
+        end
+    end
+    
+    if RTtask
+        subplot(spRows,length(cohs),c+length(cohs)*(2-(conftask==0))); hold on
+        for d = 1:length(deltas)
+            h(d) = errorbar(hdgs, squeeze(parsedData.RTmean(3,c,d,:)), squeeze(parsedData.RTse(3,c,d,:)), [clr{c}{d}],'linewidth',1.5); 
+        end
+    end
+    
+end
+
+end
+
+
+%% fit
+% plot curve only, overlaid on actual data points
+
+try 
+mods   = unique(fit.modality);
+cohs   = unique(fit.coherence);
+deltas = unique(fit.delta);
+% deltas = 0;
+hdgs   = unique(fit.heading);
+D = find(deltas==0);
+
+%%% parsedData = dots3DMP_parseData(fit,mods,cohs,deltas,hdgs,conftask,RTtask); 
+% ^ because fit may have continuous pRight/pHigh instead of binary
+% choice/PDW, use this abridged version of parseData instead:
+
+n = nan(length(mods),length(cohs),length(deltas),length(hdgs));
+pRight = n;
+pRightSE = n;
+RTmean = n; RTse = n;
+confMean = n; confSE = n;
+for m = 1:length(mods)
+for c = 1:length(cohs)
+for d = 1:length(deltas)     
+    for h = 1:length(hdgs)
+        J = fit.modality==mods(m) & fit.coherence==cohs(c) & fit.heading==hdgs(h) & fit.delta==deltas(d);
+        
+        K = J & fit.PDW==1;
+        n(m,c,d,h,1) = nansum(K);
+        pRightHigh(m,c,d,h) = nanmean(fit.pRight(K));
+        pRightHighSE(m,c,d,h) = nanstd(fit.pRight(K))/sqrt(n(m,c,d,h,1));
+
+        K = J & fit.PDW==0;
+        n(m,c,d,h,2) = nansum(K);
+        pRightLow(m,c,d,h) = nanmean(fit.pRight(K));
+        pRightLowSE(m,c,d,h) = nanstd(fit.pRight(K))/sqrt(n(m,c,d,h,2));
+        
+        if RTtask
+            K = J & fit.PDW==1;
+            RTmeanHigh(m,c,d,h) = nanmean(fit.RT(K));
+            RTHighse(m,c,d,h) = nanstd(fit.RT(J))/sqrt(n(m,c,d,h,1));
+
+            K = J & fit.PDW==0;
+            RTmeanLow(m,c,d,h) = nanmean(fit.RT(K));
+            RTLowse(m,c,d,h) = nanstd(fit.RT(J))/sqrt(n(m,c,d,h,2));
+        else
+            RTmeanHigh(m,c,d,h) = NaN;
+            RTHighse(m,c,d,h) = NaN;
+        end        
+    end
+end
+end
+end
+
+% copy vestib-only data to all coherences, to aid plotting
+for c=1:length(cohs)
+    n(1,c,:,:,:) = n(1,1,:,:,:);
+    pRightHigh(1,c,:,:) = pRightHigh(1,1,:,:);
+    pRightHighSE(1,c,:,:) = pRightHighSE(1,1,:,:);
+    RTmeanHigh(1,c,:,:) = RTmeanHigh(1,1,:,:);
+    RTHighse(1,c,:,:) = RTHighse(1,1,:,:);
+
+    pRightLow(1,c,:,:) = pRightLow(1,1,:,:);
+    pRightLowSE(1,c,:,:) = pRightLowSE(1,1,:,:);
+    RTmeanLow(1,c,:,:) = RTmeanLow(1,1,:,:);
+    RTLowse(1,c,:,:) = RTLowse(1,1,:,:);
+end
+
+% make analogous 'parsed' struct
+parsedFit = struct();
+parsedFit.pRightHigh = pRightHigh;
+parsedFit.pRightLow = pRightLow;
+if RTtask
+    parsedFit.RTmeanHigh = RTmeanHigh;
+    parsedFit.RTmeanLow = RTmeanLow;
+end
+
+catch
+    disp('using passed parsedFit')
+    parsedFit = fit;
+end
+
+
+% plot it!
+
+% first, single-cues + zero-delta comb
+
+%ves %vis %comb
+% clr{1} = {'k-','m-','c-'};
+clr{1} = {'k-','r-','b-'};
+clr{2} = {'k-','r-','b-'};
+clr{3} = {'k-','y-','g-'};
+
+hdgs = linspace(-12,12,33);
+figure(101);
+for c = 1:length(cohs)
+    subplot(spRows,length(cohs),c);
+    for m = 1:length(mods)     % m c d h
+        h(m,1) = plot(hdgs, squeeze(parsedFit.pRightHigh(m,c,D,:)), [clr{c}{m}]); hold on;
+        h(m,2) = plot(hdgs, squeeze(parsedFit.pRightLow(m,c,D,:)), 'color',[clr{c}{m}(1)] ,'Linestyle','--'); hold on;
+
+        ylim([0 1]);
+    end
+    if RTtask
+        subplot(spRows,length(cohs),c+length(cohs));
+        for m = 1:length(mods)
+            h(m) = plot(hdgs, squeeze(parsedFit.RTmeanHigh(m,c,D,:)), [clr{c}{m}]); hold on;
+            h(m) = plot(hdgs, squeeze(parsedFit.RTmeanLow(m,c,D,:)), 'color',[clr{c}{m}(1)],'linestyle','--'); hold on;
+        end
+    end
+end
+
+% now comb separated by delta
+
+clr{1} = {'b-','c-','g-'};
+clr{2} = {'b-','c-','g-'};
+clr{3} = {'b-','c-','g-'};
+
+if length(deltas)>1
+    figure(108);
+    for c = 1:length(cohs)
+        subplot(spRows,length(cohs),c); hold on
+        for d = 1:length(deltas)     % m c d h
+            h(d) = plot(hdgs, squeeze(parsedFit.pRight(3,c,d,:)), [clr{c}{d}]); 
+        end
+        if length(mods)>1; title(['coh = ' num2str(cohs(c))]); end
+        ylim([0 1]);
+        if conftask>0
+            subplot(spRows,length(cohs),c+length(cohs)); hold on
+            for d = 1:length(deltas)
+                h(d) = plot(hdgs, squeeze(parsedFit.confMean(3,c,d,:)), [clr{c}{d}]);
+            end
+        end
+        if RTtask
+            subplot(spRows,length(cohs),c+length(cohs)*(2-(conftask==0))); hold on;
+            for d = 1:length(deltas)
+                h(d) = plot(hdgs, squeeze(parsedFit.RTmean(3,c,d,:)), [clr{c}{d}]);
+            end
+        end
+    end        
+end
+
+


### PR DESCRIPTION
- implemented option to select which likelihoods to use (options.whichFit)
- cleaned up choice-wager marginals, conditional and intersections calculations (wrapped in functions)
- removed call num global and explicit plotting, just using built-in iteration plotting in fminsearch
- large clean-up to wrapper, fit k, B using choice+RT first, then theta and alpha using confidence

dots3DMP specific changes
- separate P structs for each modality (across cohs) to accommodate eventual temporal scaling
- P calculated in main loop of errfcn
- signed drift used in post-fit "dummyRun" to accommodate non-symmetrical drift rates if cue conflict is present